### PR TITLE
Simplify MemcacheClientBuilder.newStringClient() by defaulting to UTF-8

### DIFF
--- a/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -16,6 +16,7 @@
 
 package com.spotify.folsom;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -82,13 +83,26 @@ public class MemcacheClientBuilder<V> {
   }
 
   /**
-   * Create a client builder with a basic string transcoder.
-   * @param charset the charser to use for encoding/decoding strings
+   * Create a client builder with a basic string transcoder using the UTF-8
+   * Charset.
+   *
    * @return The builder
    */
-  public static MemcacheClientBuilder<String> newStringClient(final Charset charset) {
+  public static MemcacheClientBuilder<String> newStringClient() {
+    return newStringClient(Charsets.UTF_8);
+  }
+
+  /**
+   * Create a client builder with a basic string transcoder using the supplied
+   * Charset.
+   *
+   * @param charset the Charset to encode and decode String objects with.
+   * @return The builder
+   */
+  public static MemcacheClientBuilder<String> newStringClient(Charset charset) {
     return new MemcacheClientBuilder<>(new StringTranscoder(charset));
   }
+
 
   /**
    * Create a client builder with the provided value transcoder.

--- a/src/test/java/com/spotify/folsom/IntegrationTest.java
+++ b/src/test/java/com/spotify/folsom/IntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.spotify.folsom;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -124,7 +123,7 @@ public class IntegrationTest {
     int embeddedPort = ascii ? asciiEmbeddedServer.getPort() : binaryEmbeddedServer.getPort();
     int port = isEmbedded() ? embeddedPort : 11211;
 
-    MemcacheClientBuilder<String> builder = MemcacheClientBuilder.newStringClient(Charsets.UTF_8)
+    MemcacheClientBuilder<String> builder = MemcacheClientBuilder.newStringClient()
             .withAddress(HostAndPort.fromParts("127.0.0.1", port))
             .withConnections(1)
             .withMaxOutstandingRequests(100)

--- a/src/test/java/com/spotify/folsom/KetamaIntegrationTest.java
+++ b/src/test/java/com/spotify/folsom/KetamaIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package com.spotify.folsom;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.net.HostAndPort;
@@ -83,7 +82,7 @@ public class KetamaIntegrationTest {
     } else {
       throw new IllegalArgumentException(protocol);
     }
-    MemcacheClientBuilder<String> builder = MemcacheClientBuilder.newStringClient(Charsets.UTF_8)
+    MemcacheClientBuilder<String> builder = MemcacheClientBuilder.newStringClient()
             .withAddresses(servers.getAddresses())
             .withConnections(1)
             .withMaxOutstandingRequests(100)

--- a/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
+++ b/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
@@ -123,7 +123,7 @@ public class MisbehavingServerTest {
 
   private MemcacheClient<String> setupAscii(String response) throws IOException {
     server = new Server(response);
-    MemcacheClient<String> client = MemcacheClientBuilder.newStringClient(Charsets.UTF_8)
+    MemcacheClient<String> client = MemcacheClientBuilder.newStringClient()
             .withAddress(HostAndPort.fromParts("localhost", server.port))
             .withRequestTimeoutMillis(100L)
             .withRetry(false)

--- a/src/test/java/com/spotify/folsom/SimpleMemcacheClientBenchmark.java
+++ b/src/test/java/com/spotify/folsom/SimpleMemcacheClientBenchmark.java
@@ -19,7 +19,6 @@
 
 package com.spotify.folsom;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
@@ -28,7 +27,6 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
-
 import net.spy.memcached.DefaultConnectionFactory;
 import net.spy.memcached.MemcachedClient;
 import net.spy.memcached.OperationFactory;
@@ -84,7 +82,7 @@ public class SimpleMemcacheClientBenchmark {
       };
       spyClient = new MemcachedClient(defaultConnectionFactory, Collections.nCopies(NUM_CLIENT_CONNECTIONS, new InetSocketAddress("localhost", 11211)));
     } else {
-      client = MemcacheClientBuilder.newStringClient(Charsets.US_ASCII)
+      client = MemcacheClientBuilder.newStringClient()
               .withMaxOutstandingRequests(100000)
               .withAddress(HostAndPort.fromParts("127.0.0.1", 11211))
               .withConnections(NUM_CLIENT_CONNECTIONS)


### PR DESCRIPTION
Other charsets can still be used by explicitly providing a
StringTranscoder to he public constructor

I believe this change will simplify usage for new users while still retaining the flexibility (and possibly a slight speed optimisation) for power users.
