### PR TITLE
Make the connect notification functionality generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ longer be used.
 
 ### Protocol
 
-Folsom implements both the [binary protocol] and [ascii protocol].
+Folsom implements both the [binary protocol] and [ascii protocol].
 They share a common interface but also extend it with their own specializations.
 
 Which protocol to use depends on your use case. With a regular memcached backend,

--- a/README.md
+++ b/README.md
@@ -37,19 +37,38 @@ To import it with maven, use this:
       <version>0.6.1</version>
     </dependency>
 
-We are using semantic versioning which means and we are currently still in
+We are using |semantic versioning](http://semver.org) which means and we are currently still in
 the initial development phase. This does not mean that the code is not stable,
 it just means that the API is not necessarily finalized.
 
     Major version zero (0.y.z) is for initial development.
     Anything may change at any time. The public API should not be considered stable.
 
-### Example usage
+### Usage
+
+The main entry point to the folsom API is the MemcacheClientBuilder class. It has
+chainable setter methods to configure various aspects of the client. The methods connectBinary()
+and connectAscii() constructs MemcacheClient instances utilising the [binary protocol] and
+[ascii protocol] respectively. For details on their differences see **Protocol** below.
+
+All calls to the folsom API that interacts with a memcache server is asynchronous and the
+result is typically accessible from ListenableFuture instances. An exception to this rule
+are the methods that connects clients to their remote endpoints,
+MemcacheClientBuilder.connectBinary() and MemcacheClientBuilder.connectAscii() which will
+return a MemcacheClient immediately while asynchronously attempting to connect to the configured
+remote endpoint(s).
+
+As code using the folsom API should be written so that it handles failing intermittently with
+MemcacheClosedException anyway, waiting for the initial connect to complete is not something
+folsom concerns itself with. For single server connections, ConnectFuture provides functionality
+to wait for the initial connection to succeed, as can be seen in the example below.
 
 ```Java
 final MemcacheClient<String> client = MemcacheClientBuilder.newStringClient()
     .withAddresses(Collections.singletonList(host))
     .connectAscii();
+// make we wait until the client has connected to the server
+ConnectFuture.connectFuture(client).get();
 
 client.set("key", "value", 10000).get();
 client.get("key").get();
@@ -79,13 +98,9 @@ longer be used.
   race condition bugs and deadlocks. We try to isolate that as much as possible to minimize the risk,
   and most of the code base doesn't have to care.
 
-### Futures
-
-All request operations return a Guava ListenableFuture.
-
 ### Protocol
 
-Folsom implements both the binary and ascii protocol.
+Folsom implements both the [binary protocol] and [ascii protocol].
 They share a common interface but also extend it with their own specializations.
 
 Which protocol to use depends on your use case. With a regular memcached backend,
@@ -120,17 +135,12 @@ You can optionally choose to track performance using yammer metrics.
 mvn package
 ```
 
-### References
-
-https://code.google.com/p/memcached/wiki/BinaryProtocolRevamped
-https://github.com/memcached/memcached/blob/master/doc/protocol.txt
-
 ### Authors
-
-Authors
--------
 
 Folsom was initially built at [Spotify](<https://github.com/spotify) by
 [Kristofer Karlsson](https://github.com/krka), [Niklas Gustavsson](https://github.com/protocol7) and
 [Daniel Norberg](https://github.com/danielnorberg).
 Many thanks also go out to [Noa Resare](https://github.com/noaresare).
+
+[binary protocol]: https://code.google.com/p/memcached/wiki/BinaryProtocolRevamped
+[ascii protocol]: https://github.com/memcached/memcached/blob/master/doc/protocol.txt

--- a/src/main/java/com/spotify/folsom/ConnectFuture.java
+++ b/src/main/java/com/spotify/folsom/ConnectFuture.java
@@ -29,26 +29,26 @@ public class ConnectFuture
    * @param client
    * @param awaitedState
    */
-  private ConnectFuture(RawMemcacheClient client, boolean awaitedState) {
+  private ConnectFuture(ObservableClient client, boolean awaitedState) {
     this.awaitedState = awaitedState;
     client.registerForConnectionChanges(this);
     check(client);
   }
 
-  public static ListenableFuture<Void> disconnectFuture(RawMemcacheClient client) {
+  public static ListenableFuture<Void> disconnectFuture(ObservableClient client) {
     return new ConnectFuture(client, false);
   }
 
-  public static ListenableFuture<Void> connectFuture(RawMemcacheClient client) {
+  public static ListenableFuture<Void> connectFuture(ObservableClient client) {
     return new ConnectFuture(client, true);
   }
 
   @Override
-  public void connectionChanged(RawMemcacheClient client) {
+  public void connectionChanged(ObservableClient client) {
     check(client);
   }
 
-  private void check(RawMemcacheClient client) {
+  private void check(ObservableClient client) {
     if (awaitedState == client.isConnected()) {
       if (set(null)) {
         client.unregisterForConnectionChanges(this);

--- a/src/main/java/com/spotify/folsom/ConnectionChangeListener.java
+++ b/src/main/java/com/spotify/folsom/ConnectionChangeListener.java
@@ -20,5 +20,5 @@ import com.google.common.eventbus.Subscribe;
 public interface ConnectionChangeListener {
 
   @Subscribe
-  void connectionChanged(RawMemcacheClient client);
+  void connectionChanged(ObservableClient client);
 }

--- a/src/main/java/com/spotify/folsom/MemcacheClient.java
+++ b/src/main/java/com/spotify/folsom/MemcacheClient.java
@@ -19,7 +19,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 
-public interface MemcacheClient<V> {
+public interface MemcacheClient<V> extends ObservableClient {
 
   /**
    * Set a key in memcache to the provided value, with the specified TTL
@@ -121,13 +121,6 @@ public interface MemcacheClient<V> {
    * Shut down the client.
    */
   void shutdown();
-
-  /**
-   * Is the client connected to a server?
-   *
-   * @return true if the client is connected
-   */
-  boolean isConnected();
 
   /**
    * How many actual socket connections do we have, including currently disconnected clients.

--- a/src/main/java/com/spotify/folsom/ObservableClient.java
+++ b/src/main/java/com/spotify/folsom/ObservableClient.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package com.spotify.folsom;
+
+/**
+ * Implementations of this interface has a notion of connectedness to a remote
+ * and the ability to notify listeners of connection state changes.
+ */
+public interface ObservableClient {
+  /**
+   * Register for connection change events. This should trigger at least once for every
+   * connection change. You should immediately get an initial callback, so that if you
+   * are creating a ListenableFuture looking for a connection state that has already
+   * been reached it will return immediately.
+   *
+   * @param listener the listener to notify of connection changes
+   */
+  void registerForConnectionChanges(ConnectionChangeListener listener);
+
+  /**
+   * Unregister the provided listener so that it no longer receives connection change
+   * callbacks.
+   * @param listener the listener to unregister.
+   */
+  void unregisterForConnectionChanges(ConnectionChangeListener listener);
+
+  /**
+   * Is the client connected to a server?
+   * @return true if the client is connected
+   */
+  boolean isConnected();
+}

--- a/src/main/java/com/spotify/folsom/RawMemcacheClient.java
+++ b/src/main/java/com/spotify/folsom/RawMemcacheClient.java
@@ -22,7 +22,7 @@ import com.spotify.folsom.client.Request;
 /**
  * A raw memcache client, mostly useful internally
  */
-public interface RawMemcacheClient {
+public interface RawMemcacheClient extends ObservableClient {
 
   <T> ListenableFuture<T> send(Request<T> request);
 
@@ -31,12 +31,6 @@ public interface RawMemcacheClient {
    * to get notified when it has (possibly) finished shutting down
    */
   void shutdown();
-
-  /**
-   * Is the client connected to a server?
-   * @return true if the client is connected
-   */
-  boolean isConnected();
 
   /**
    * How many actual socket connections do we have, including currently disconnected clients.
@@ -49,17 +43,4 @@ public interface RawMemcacheClient {
    * @return the number of active connections
    */
   int numActiveConnections();
-
-  /**
-   * Register for connection change events. This should trigger at least once for every
-   * connection change. You should immediately get an initial callback.
-   * @param listener
-   */
-  void registerForConnectionChanges(ConnectionChangeListener listener);
-
-  /**
-   * Unregister for connection change events.
-   * @param listener
-   */
-  void unregisterForConnectionChanges(ConnectionChangeListener listener);
 }

--- a/src/main/java/com/spotify/folsom/client/AbstractMultiMemcacheClient.java
+++ b/src/main/java/com/spotify/folsom/client/AbstractMultiMemcacheClient.java
@@ -19,6 +19,7 @@ package com.spotify.folsom.client;
 import com.google.common.base.Preconditions;
 import com.spotify.folsom.AbstractRawMemcacheClient;
 import com.spotify.folsom.ConnectionChangeListener;
+import com.spotify.folsom.ObservableClient;
 import com.spotify.folsom.RawMemcacheClient;
 
 import java.util.Collection;
@@ -79,7 +80,7 @@ public abstract class AbstractMultiMemcacheClient
   }
 
   @Override
-  public void connectionChanged(RawMemcacheClient client) {
+  public void connectionChanged(ObservableClient client) {
     notifyConnectionChange();
   }
 }

--- a/src/main/java/com/spotify/folsom/client/ascii/DefaultAsciiMemcacheClient.java
+++ b/src/main/java/com/spotify/folsom/client/ascii/DefaultAsciiMemcacheClient.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.spotify.folsom.AsciiMemcacheClient;
+import com.spotify.folsom.ConnectionChangeListener;
 import com.spotify.folsom.GetResult;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.Metrics;
@@ -218,9 +219,19 @@ public class DefaultAsciiMemcacheClient<V> implements AsciiMemcacheClient<V> {
     rawMemcacheClient.shutdown();
   }
 
+  @Override
+  public void registerForConnectionChanges(ConnectionChangeListener listener) {
+    rawMemcacheClient.registerForConnectionChanges(listener);
+  }
+
+  @Override
+  public void unregisterForConnectionChanges(ConnectionChangeListener listener) {
+    rawMemcacheClient.unregisterForConnectionChanges(listener);
+  }
+
   /*
-   * @see com.spotify.folsom.BinaryMemcacheClient#isConnected()
-   */
+     * @see com.spotify.folsom.BinaryMemcacheClient#isConnected()
+     */
   @Override
   public boolean isConnected() {
     return rawMemcacheClient.isConnected();

--- a/src/main/java/com/spotify/folsom/client/binary/DefaultBinaryMemcacheClient.java
+++ b/src/main/java/com/spotify/folsom/client/binary/DefaultBinaryMemcacheClient.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.spotify.folsom.BinaryMemcacheClient;
+import com.spotify.folsom.ConnectionChangeListener;
 import com.spotify.folsom.GetResult;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.Metrics;
@@ -322,9 +323,19 @@ public class DefaultBinaryMemcacheClient<V> implements BinaryMemcacheClient<V> {
     rawMemcacheClient.shutdown();
   }
 
+  @Override
+  public void registerForConnectionChanges(ConnectionChangeListener listener) {
+    rawMemcacheClient.registerForConnectionChanges(listener);
+  }
+
+  @Override
+  public void unregisterForConnectionChanges(ConnectionChangeListener listener) {
+    rawMemcacheClient.registerForConnectionChanges(listener);
+  }
+
   /*
-   * @see com.spotify.folsom.BinaryMemcacheClient#isConnected()
-   */
+     * @see com.spotify.folsom.BinaryMemcacheClient#isConnected()
+     */
   @Override
   public boolean isConnected() {
     return rawMemcacheClient.isConnected();

--- a/src/main/java/com/spotify/folsom/ketama/SrvKetamaClient.java
+++ b/src/main/java/com/spotify/folsom/ketama/SrvKetamaClient.java
@@ -229,7 +229,7 @@ public class SrvKetamaClient extends AbstractRawMemcacheClient {
 
   private class MyConnectionChangeListener implements ConnectionChangeListener {
     @Override
-    public void connectionChanged(RawMemcacheClient client) {
+    public void connectionChanged(ObservableClient client) {
       notifyConnectionChange();
     }
   }

--- a/src/main/java/com/spotify/folsom/ketama/SrvKetamaClient.java
+++ b/src/main/java/com/spotify/folsom/ketama/SrvKetamaClient.java
@@ -25,6 +25,7 @@ import com.spotify.dns.DnsSrvResolver;
 import com.spotify.folsom.AbstractRawMemcacheClient;
 import com.spotify.folsom.ConnectFuture;
 import com.spotify.folsom.ConnectionChangeListener;
+import com.spotify.folsom.ObservableClient;
 import com.spotify.folsom.RawMemcacheClient;
 import com.spotify.folsom.client.NotConnectedClient;
 import com.spotify.folsom.client.Request;

--- a/src/test/java/com/spotify/folsom/IntegrationTest.java
+++ b/src/test/java/com/spotify/folsom/IntegrationTest.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.spotify.folsom.client.NoopMetrics;
 import com.spotify.folsom.client.Utils;
 import junit.framework.AssertionFailedError;
@@ -47,7 +46,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -106,12 +104,6 @@ public class IntegrationTest {
     asciiEmbeddedServer.stop();
   }
 
-  public static void awaitConnected(final MemcacheClient<?> client) {
-    while (client != null && client.numActiveConnections() < client.numTotalConnections()) {
-      Uninterruptibles.sleepUninterruptibly(1, TimeUnit.MILLISECONDS);
-    }
-  }
-
   @Before
   public void setUp() throws Exception {
     boolean ascii;
@@ -143,7 +135,7 @@ public class IntegrationTest {
       asciiClient = null;
       client = binaryClient;
     }
-    awaitConnected(client);
+    ConnectFuture.connectFuture(client).get();
     System.out.println("Using client: " + client + ", protocol: " + protocol + " and port: " + port);
     cleanup();
   }

--- a/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
+++ b/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
@@ -43,7 +43,7 @@ public class MemcacheClientBuilderTest {
             .withKeyCharset(Charsets.ISO_8859_1)
             .withAddress(HostAndPort.fromParts("localhost", server.getPort()))
             .connectAscii();
-    IntegrationTest.awaitConnected(client);
+    ConnectFuture.connectFuture(client).get();
     assertEquals(null, client.get("Räksmörgås").get());
   }
 
@@ -53,7 +53,7 @@ public class MemcacheClientBuilderTest {
             .withKeyCharset(Charsets.UTF_8)
             .withAddress(HostAndPort.fromParts("localhost", server.getPort()))
             .connectAscii();
-    IntegrationTest.awaitConnected(client);
+    ConnectFuture.connectFuture(client).get();
     assertEquals(null, client.get("Räksmörgås").get());
   }
 
@@ -63,7 +63,7 @@ public class MemcacheClientBuilderTest {
             .withKeyCharset(Charsets.UTF_16)
             .withAddress(HostAndPort.fromParts("localhost", server.getPort()))
             .connectAscii();
-    IntegrationTest.awaitConnected(client);
+    ConnectFuture.connectFuture(client).get();
     client.get("Key").get();
   }
 }

--- a/src/test/java/com/spotify/folsom/MemcacheClientStressTest.java
+++ b/src/test/java/com/spotify/folsom/MemcacheClientStressTest.java
@@ -60,7 +60,7 @@ public class MemcacheClientStressTest {
     client = MemcacheClientBuilder.newByteArrayClient()
         .withAddress(HostAndPort.fromParts("127.0.0.1", daemon.getPort()))
         .connectAscii();
-    IntegrationTest.awaitConnected(client);
+    ConnectFuture.connectFuture(client).get();
   }
 
   public static void main(final String[] args) throws Exception {

--- a/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
+++ b/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
@@ -145,7 +145,7 @@ public class MisbehavingServerTest {
     testAsciiSet("TOUCHED\r\n", "Unexpected line: TOUCHED");
   }
 
-  private void testAsciiGet(String response, String expectedError) throws InterruptedException, IOException {
+  private void testAsciiGet(String response, String expectedError) throws Exception {
     MemcacheClient<String> client = setupAscii(response);
     try {
       client.get("key").get();
@@ -157,7 +157,7 @@ public class MisbehavingServerTest {
     }
   }
 
-  private void testAsciiTouch(String response, String expectedError) throws InterruptedException, IOException {
+  private void testAsciiTouch(String response, String expectedError) throws Exception {
     MemcacheClient<String> client = setupAscii(response);
     try {
       client.touch("key", 123).get();
@@ -169,7 +169,7 @@ public class MisbehavingServerTest {
     }
   }
 
-  private void testAsciiSet(String response, String expectedError) throws InterruptedException, IOException {
+  private void testAsciiSet(String response, String expectedError) throws Exception {
     MemcacheClient<String> client = setupAscii(response);
     try {
       client.set("key", "value", 123).get();
@@ -181,14 +181,14 @@ public class MisbehavingServerTest {
     }
   }
 
-  private MemcacheClient<String> setupAscii(String response) throws IOException {
+  private MemcacheClient<String> setupAscii(String response) throws Exception {
     server = new Server(response);
     MemcacheClient<String> client = MemcacheClientBuilder.newStringClient()
             .withAddress(HostAndPort.fromParts("localhost", server.port))
             .withRequestTimeoutMillis(100L)
             .withRetry(false)
             .connectAscii();
-    IntegrationTest.awaitConnected(client);
+    ConnectFuture.connectFuture(client).get();
     return client;
   }
 

--- a/src/test/java/com/spotify/folsom/client/YammerMetricsTest.java
+++ b/src/test/java/com/spotify/folsom/client/YammerMetricsTest.java
@@ -17,8 +17,8 @@ package com.spotify.folsom.client;
 
 import com.google.common.base.Charsets;
 import com.spotify.folsom.AsciiMemcacheClient;
+import com.spotify.folsom.ConnectFuture;
 import com.spotify.folsom.FakeRawMemcacheClient;
-import com.spotify.folsom.IntegrationTest;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.ascii.DefaultAsciiMemcacheClient;
 import com.spotify.folsom.transcoder.StringTranscoder;
@@ -43,7 +43,7 @@ public class YammerMetricsTest {
     client = new DefaultAsciiMemcacheClient<>(
             new FakeRawMemcacheClient(), metrics,
             StringTranscoder.UTF8_INSTANCE, Charsets.UTF_8);
-    IntegrationTest.awaitConnected(client);
+    ConnectFuture.connectFuture(client).get();
   }
 
   @Test


### PR DESCRIPTION
Introduce a new super interface ObservableClient extended by both RawMemcacheClient
and the higher level interfaces.
