### PR TITLE
added transcoder for serializable objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>dns</artifactId>
       <version>2.2.0</version>
     </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
 
     <!-- Tests -->
     <dependency>

--- a/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -34,8 +34,10 @@ import com.spotify.folsom.reconnect.ReconnectingClient;
 import com.spotify.folsom.retry.RetryingClient;
 import com.spotify.folsom.roundrobin.RoundRobinMemcacheClient;
 import com.spotify.folsom.transcoder.ByteArrayTranscoder;
+import com.spotify.folsom.transcoder.SerializableObjectTranscoder;
 import com.spotify.folsom.transcoder.StringTranscoder;
 
+import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -135,6 +137,14 @@ public class MemcacheClientBuilder<V> {
    */
   public static MemcacheClientBuilder<String> newStringClient(Charset charset) {
     return new MemcacheClientBuilder<>(new StringTranscoder(charset));
+  }
+
+  /**
+   * Create a client builder for serializable object values.
+   * @return The builder
+   */
+  public static MemcacheClientBuilder<Serializable> newSerializableObjectClient() {
+    return new MemcacheClientBuilder<>(SerializableObjectTranscoder.INSTANCE);
   }
 
 

--- a/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
+++ b/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom.transcoder;
+
+import com.spotify.folsom.Transcoder;
+import org.apache.commons.lang.SerializationUtils;
+
+import java.io.Serializable;
+
+
+public final class SerializableObjectTranscoder implements Transcoder<Serializable> {
+
+  public static final SerializableObjectTranscoder INSTANCE = new SerializableObjectTranscoder();
+
+  private SerializableObjectTranscoder() {
+  }
+
+  @Override
+  public byte[] encode(final Serializable t) {
+    return SerializationUtils.serialize(t);
+  }
+
+  @Override
+  public Serializable decode(final byte[] b) {
+    return (Serializable) SerializationUtils.deserialize(b);
+  }
+
+}

--- a/src/test/java/com/spotify/folsom/transcoder/SerializableObjectTranscoderTest.java
+++ b/src/test/java/com/spotify/folsom/transcoder/SerializableObjectTranscoderTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.folsom.transcoder;
+
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+
+public class SerializableObjectTranscoderTest {
+
+  private static final class SerializableTestObject implements Serializable {
+    private static final long serialVersionUID = 6961370831727465915L;
+    private String value1;
+    private String value2;
+    private int value3;
+  }
+
+  @Test
+  public void testEncodeDecode() {
+    SerializableTestObject b = new SerializableTestObject();
+    b.value1 = "hello";
+    b.value2 = "world";
+    b.value3 = 5;
+
+    final byte[] encoded = SerializableObjectTranscoder.INSTANCE.encode(b);
+    final SerializableTestObject testObject =
+            (SerializableTestObject) SerializableObjectTranscoder.INSTANCE.decode(encoded);
+
+    assertEquals("hello", testObject.value1);
+    assertEquals("world", testObject.value2);
+    assertEquals(5, testObject.value3);
+  }
+}


### PR DESCRIPTION
Caching serializable objects is an extremely common use case and is the easiest way to use memcached and folsom out of the box.
