### PR TITLE
add metrics gauge for pending request count

### DIFF
--- a/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -443,6 +443,8 @@ public class MemcacheClientBuilder<V> {
         maxOutstandingRequests,
         binary,
         executor,
-        timeoutMillis, charset);
+        timeoutMillis,
+        charset,
+        metrics);
   }
 }

--- a/src/main/java/com/spotify/folsom/Metrics.java
+++ b/src/main/java/com/spotify/folsom/Metrics.java
@@ -27,4 +27,15 @@ public interface Metrics {
   void measureSetFuture(ListenableFuture<MemcacheStatus> future);
   void measureIncrDecrFuture(ListenableFuture<Long> future);
   void measureTouchFuture(ListenableFuture<MemcacheStatus> future);
+
+  /**
+   * Called by the MemcacheClient initialization process to allow a gauge to be registered with the
+   * metrics implementation to monitor the number of outstanding requests at any moment in time.
+   */
+  void registerOutstandingRequestsGauge(OutstandingRequestsGauge gauge);
+
+  interface OutstandingRequestsGauge {
+    int getOutstandingRequests();
+  }
+
 }

--- a/src/main/java/com/spotify/folsom/client/NoopMetrics.java
+++ b/src/main/java/com/spotify/folsom/client/NoopMetrics.java
@@ -55,4 +55,9 @@ public class NoopMetrics implements Metrics {
   public void measureTouchFuture(ListenableFuture<MemcacheStatus> future) {
 
   }
+
+  @Override
+  public void registerOutstandingRequestsGauge(OutstandingRequestsGauge gauge) {
+
+  }
 }

--- a/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -26,6 +26,7 @@ import com.spotify.folsom.ConnectFuture;
 import com.spotify.folsom.Metrics;
 import com.spotify.folsom.RawMemcacheClient;
 import com.spotify.folsom.client.DefaultRawMemcacheClient;
+import com.spotify.folsom.client.NoopMetrics;
 import com.spotify.folsom.client.NotConnectedClient;
 import com.spotify.folsom.client.Request;
 import org.slf4j.Logger;
@@ -55,6 +56,18 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
   private volatile RawMemcacheClient client = NotConnectedClient.INSTANCE;
   private volatile int reconnectCount = 0;
   private volatile boolean stayConnected = true;
+
+  public ReconnectingClient(final BackoffFunction backoffFunction,
+                            final ScheduledExecutorService scheduledExecutorService,
+                            final HostAndPort address,
+                            final int outstandingRequestLimit,
+                            final boolean binary,
+                            final Executor executor,
+                            final long timeoutMillis,
+                            final Charset charset) {
+    this(backoffFunction, scheduledExecutorService, address, outstandingRequestLimit,
+        binary, executor, timeoutMillis, charset, new NoopMetrics());
+  }
 
   public ReconnectingClient(final BackoffFunction backoffFunction,
                             final ScheduledExecutorService scheduledExecutorService,

--- a/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -23,6 +23,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.spotify.folsom.AbstractRawMemcacheClient;
 import com.spotify.folsom.BackoffFunction;
 import com.spotify.folsom.ConnectFuture;
+import com.spotify.folsom.Metrics;
 import com.spotify.folsom.RawMemcacheClient;
 import com.spotify.folsom.client.DefaultRawMemcacheClient;
 import com.spotify.folsom.client.NotConnectedClient;
@@ -62,13 +63,14 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
                             final boolean binary,
                             final Executor executor,
                             final long timeoutMillis,
-                            final Charset charset) {
+                            final Charset charset,
+                            final Metrics metrics) {
     this(backoffFunction, scheduledExecutorService, new Connector() {
       @Override
       public ListenableFuture<RawMemcacheClient> connect() {
         return DefaultRawMemcacheClient.connect(
                 address, outstandingRequestLimit,
-                binary, executor, timeoutMillis, charset);
+                binary, executor, timeoutMillis, charset, metrics);
       }
     }, address);
   }

--- a/src/test/java/com/spotify/folsom/FakeRawMemcacheClient.java
+++ b/src/test/java/com/spotify/folsom/FakeRawMemcacheClient.java
@@ -19,9 +19,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.spotify.folsom.client.MultiRequest;
-import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.GetRequest;
+import com.spotify.folsom.client.MultiRequest;
+import com.spotify.folsom.client.NoopMetrics;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.SetRequest;
 import com.spotify.folsom.client.ascii.DeleteRequest;
 import com.spotify.folsom.client.ascii.IncrRequest;
@@ -35,6 +36,20 @@ public class FakeRawMemcacheClient extends AbstractRawMemcacheClient {
 
   private boolean connected = true;
   private final Map<ByteBuffer, byte[]> map = Maps.newHashMap();
+  private int outstanding = 0;
+
+  public FakeRawMemcacheClient() {
+    this(new NoopMetrics());
+  }
+
+  public FakeRawMemcacheClient(Metrics metrics) {
+    metrics.registerOutstandingRequestsGauge(new Metrics.OutstandingRequestsGauge() {
+      @Override
+      public int getOutstandingRequests() {
+        return outstanding;
+      }
+    });
+  }
 
   @Override
   public <T> ListenableFuture<T> send(Request<T> request) {
@@ -118,5 +133,9 @@ public class FakeRawMemcacheClient extends AbstractRawMemcacheClient {
 
   public Map<ByteBuffer, byte[]> getMap() {
     return map;
+  }
+
+  public void setOutstandingRequests(int outstanding) {
+    this.outstanding = outstanding;
   }
 }

--- a/src/test/java/com/spotify/folsom/client/SlowStaticServer.java
+++ b/src/test/java/com/spotify/folsom/client/SlowStaticServer.java
@@ -1,0 +1,83 @@
+package com.spotify.folsom.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class SlowStaticServer implements Closeable {
+
+  private static final Logger log = LoggerFactory.getLogger(SlowStaticServer.class);
+
+  private final ScheduledExecutorService executor;
+  private final byte[] response;
+  private final int delayMillis;
+
+  private volatile boolean shutdown = false;
+  private ServerSocket serverSocket;
+
+  public SlowStaticServer(byte[] response, int delayMillis) {
+    this.executor = Executors.newScheduledThreadPool(10);
+    this.response = response;
+    this.delayMillis = delayMillis;
+  }
+
+  public int start(int listenPort) throws IOException {
+    serverSocket = new ServerSocket(listenPort);
+    executor.execute(new Listener());
+    return serverSocket.getLocalPort();
+  }
+
+  @Override
+  public void close() {
+    if (!shutdown) {
+      shutdown = true;
+      executor.shutdownNow();
+      try {
+        serverSocket.close();
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  private class Listener implements Runnable {
+
+    @Override
+    public void run() {
+      try {
+        // expect just one connection
+        final Socket socket = serverSocket.accept();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+        while (!shutdown) {
+          String line = reader.readLine();
+          if (!line.startsWith("get ")) {
+            throw new RuntimeException("Unimplemented command: " + line);
+          }
+          executor.schedule(new Runnable() {
+            @Override
+            public void run() {
+              try {
+                socket.getOutputStream().write(response);
+                socket.getOutputStream().flush();
+                log.debug("sent response");
+              } catch (IOException e) {
+                log.error("exception with socket", e);
+              }
+            }
+          }, delayMillis, TimeUnit.MILLISECONDS);
+        }
+      } catch (IOException e) {
+        log.debug("shutting down due to error", e);
+        close();
+      }
+    }
+  }
+}

--- a/src/test/java/com/spotify/folsom/client/SlowStaticServer.java
+++ b/src/test/java/com/spotify/folsom/client/SlowStaticServer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.spotify.folsom.client;
 
 import org.slf4j.Logger;


### PR DESCRIPTION
Allows for monitoring of the number of pending operations.

Changes to support this are more extensive than might be expected since
unlike other metrics that can be "pushed" into the Metrics
implementation, there needs to be a way for the Metrics implementation
to "pull" the pending operation count when it is interested in reporting
the values (otherwise the DefaultRawMemcacheClient would have to inform
the Metrics implementation every single time the pending operation
counter changed value).

Also needed to make changes to pass the Metrics instance down to
the DefaultRawMemcacheClient layer since the pending count is only
kept there.
