### PR TITLE
Add consistent support for 0 TTL

### DIFF
--- a/src/main/java/com/spotify/folsom/client/Utils.java
+++ b/src/main/java/com/spotify/folsom/client/Utils.java
@@ -64,7 +64,7 @@ public final class Utils {
   }
 
   public static int ttlToExpiration(final int ttl) {
-    return (int) (System.currentTimeMillis() / 1000) + ttl;
+    return (ttl == 0) ? 0 : (int) (System.currentTimeMillis() / 1000) + ttl;
   }
 
   public static <T> Function<List<List<T>>, List<T>> flatten() {


### PR DESCRIPTION
According to the [spec](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L163), a TTL of 0 should be treated as 'do not expire'.

@spkrka
