### PR TITLE
fix binary req retries - allow setOpaque() twice

### DIFF
--- a/src/main/java/com/spotify/folsom/client/binary/BinaryRequest.java
+++ b/src/main/java/com/spotify/folsom/client/binary/BinaryRequest.java
@@ -84,9 +84,6 @@ public abstract class BinaryRequest<V> extends Request<V> {
   protected abstract void handle(BinaryResponse response) throws IOException;
 
   public void setOpaque(int opaque) {
-    if (this.opaqueSet) {
-      throw new IllegalStateException("opaque may not be set more than one");
-    }
     this.opaqueSet = true;
     this.opaque = (opaque << 8) & 0xFFFFFF00;
   }


### PR DESCRIPTION
https://github.com/spotify/folsom/issues/60

The retrying client retries by re-sending the original request. The underlying binary memcache protocol implementation did not allow resending requests. 
- Remove the restriction of only allowing one call to setOpaque().
- Add tests to verify that both the raw ascii and raw binary clients allow request resends.
