### PR TITLE
Throw MemcacheTimeoutException instead of logging ERROR for request timeout

### DIFF
--- a/src/main/java/com/spotify/folsom/MemcacheTimeoutException.java
+++ b/src/main/java/com/spotify/folsom/MemcacheTimeoutException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2014-2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom;
+
+public class MemcacheTimeoutException extends MemcacheClosedException {
+  public MemcacheTimeoutException(final String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/spotify/folsom/client/TimeoutChecker.java
+++ b/src/main/java/com/spotify/folsom/client/TimeoutChecker.java
@@ -18,7 +18,7 @@ package com.spotify.folsom.client;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A utility for checking whether some state has changed within a specified timout. Could be used
+ * A utility for checking whether some state has changed within a specified timeout. Could be used
  * to verify that the head of a request queue changes quickly enough, indicating forward progress.
  */
 class TimeoutChecker<T> {
@@ -44,6 +44,10 @@ class TimeoutChecker<T> {
 
     // Timed out?
     return nowNanos - timestamp > timeoutNanos;
+  }
+
+  public long elapsed() {
+    return (timestamp > 0) ? System.nanoTime() - timestamp : 0;
   }
 
   public static <T> TimeoutChecker<T> create(final TimeUnit unit, final long timeout) {

--- a/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
+++ b/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
@@ -30,6 +30,7 @@ import java.net.Socket;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class MisbehavingServerTest {
@@ -96,7 +97,7 @@ public class MisbehavingServerTest {
 
   @Test
   public void testBadAsciiGet5() throws Throwable {
-    testAsciiGet("VALUE key 123 456\r\n", "Timeout");
+    testAsciiGetWithTimeout("VALUE key 123 456\r\n", "Request timeout");
   }
 
   @Test
@@ -156,6 +157,19 @@ public class MisbehavingServerTest {
       assertEquals(expectedError, cause.getMessage());
     }
   }
+
+  private void testAsciiGetWithTimeout(String response, String expectedError) throws Exception {
+    MemcacheClient<String> client = setupAscii(response);
+    try {
+      client.get("key").get();
+      fail();
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      assertEquals(MemcacheTimeoutException.class, cause.getClass());
+      assertTrue(cause.getMessage().contains(expectedError));
+    }
+  }
+
 
   private void testAsciiTouch(String response, String expectedError) throws Exception {
     MemcacheClient<String> client = setupAscii(response);

--- a/src/test/java/com/spotify/folsom/RecoveryTest.java
+++ b/src/test/java/com/spotify/folsom/RecoveryTest.java
@@ -109,8 +109,7 @@ public class RecoveryTest {
         final Throwable cause = e.getCause();
         if (cause instanceof MemcacheOverloadedException) {
           overloaded++;
-        } else if (cause instanceof MemcacheClosedException &&
-                   cause.getMessage().contains("Timeout")) {
+        } else if (cause instanceof MemcacheClosedException) {
           timeout++;
         }
       }

--- a/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
+++ b/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
@@ -26,6 +26,7 @@ import com.spotify.folsom.ConnectFuture;
 import com.spotify.folsom.EmbeddedServer;
 import com.spotify.folsom.GetResult;
 import com.spotify.folsom.MemcacheClosedException;
+import com.spotify.folsom.MemcacheTimeoutException;
 import com.spotify.folsom.RawMemcacheClient;
 import com.spotify.folsom.client.ascii.AsciiRequest;
 import com.spotify.folsom.client.ascii.AsciiResponse;
@@ -179,7 +180,7 @@ public class DefaultRawMemcacheClientTest {
       future.get();
       fail();
     } catch (ExecutionException e) {
-      assertTrue(e.getCause() instanceof MemcacheClosedException);
+      assertTrue(e.getCause() instanceof MemcacheTimeoutException);
     }
   }
 


### PR DESCRIPTION
Reference https://github.com/spotify/folsom/issues/67

Alters `DefaultRawMemcacheClient` to throw a `MemcacheTimeoutException` instead of logging ERROR for request timeout.

Timeouts dont necessarily indicate a problem with the remote system (maybe a packet was lost).

So rather than logging this as an ERROR, fails the request with `MemcacheTimeoutException`. Upstream caller can determine their course of action with the timeout: log it, retry, fallback to origin, etc.

The new exception class `MemcacheTimeoutException` extends `MemcacheClosedException`...because the client still closes the conn...so its a special case of this broader exception.

Exception is created with the following message:

```
Request timeout after 100.247631 ms: [id: 0xf3810f83, /127.0.0.1:60562 => localhost/127.0.0.1:60560] com.spotify.folsom.client.ascii.GetRequest@2bb20830
```

Elapsed time is calculated by adding an `elapsed()` method to the `TimeoutChecker`

Finally, retained the log  message in `DefaultRawMemcacheClient`, but only as a **debug**...so if someone **really** wants to see the timeouts at this level, they can configure the logger for the class.