### PR TITLE
Shutdown the client on failure to connect and lost of connection

### DIFF
--- a/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -129,6 +129,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
             @Override
             public void onSuccess(final Void ignore) {
               log.info("Lost connection to {}", address);
+              client.shutdown();
               notifyConnectionChange();
               if (stayConnected) {
                 retry();
@@ -153,6 +154,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
   }
 
   private void onFailure() {
+    client.shutdown();
     final long backOff = backoffFunction.getBackoffTimeMillis(reconnectCount);
 
     if (stayConnected) {


### PR DESCRIPTION
I think it wouldn't hurt to call `shutdown()` on the internal client in the `ReconnectingClient` when a connection failed to be establish and when the connection is lost. This will assure that the underlying channel get closed properly and potentially prevents any kind of connection leakage.

Is there any cons in doing this?