### PR TITLE
Specifiable Netty EventLoopGroup and executor

### DIFF
--- a/folsom-semantic-metrics/pom.xml
+++ b/folsom-semantic-metrics/pom.xml
@@ -8,7 +8,6 @@
   </parent>
 
   <artifactId>folsom-semantic-metrics</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
 
   <developers>
     <developer>

--- a/folsom/pom.xml
+++ b/folsom/pom.xml
@@ -9,9 +9,12 @@
   </parent>
 
   <artifactId>folsom</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>folsom</name>
+
+  <properties>
+    <netty.version>4.1.23.Final</netty.version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -22,7 +25,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>24.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -32,12 +35,17 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-transport</artifactId>
-      <version>4.0.48.Final</version>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
-      <version>4.0.48.Final</version>
+      <version>${netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-epoll</artifactId>
+      <version>${netty.version}</version>
     </dependency>
     <dependency>
       <groupId>com.yammer.metrics</groupId>

--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -119,7 +119,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
       decoder = new AsciiMemcacheDecoder(charset);
     }
 
-    final ChannelHandler initializer = new ChannelInitializer() {
+    final ChannelHandler initializer = new ChannelInitializer<Channel>() {
       @Override
       protected void initChannel(final Channel ch) throws Exception {
         ch.pipeline().addLast(

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -25,6 +25,8 @@ import com.spotify.folsom.RawMemcacheClient;
 import com.spotify.folsom.client.DefaultRawMemcacheClient;
 import com.spotify.folsom.client.NotConnectedClient;
 import com.spotify.folsom.client.Request;
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,10 +64,13 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
                             final long timeoutMillis,
                             final Charset charset,
                             final Metrics metrics,
-                            final int maxSetLength) {
+                            final int maxSetLength,
+                            final EventLoopGroup eventLoopGroup,
+                            final Class<? extends Channel> channelClass) {
     this(backoffFunction, scheduledExecutorService, () -> DefaultRawMemcacheClient.connect(
             address, outstandingRequestLimit,
-            binary, executor, timeoutMillis, charset, metrics, maxSetLength), address);
+            binary, executor, timeoutMillis, charset,
+            metrics, maxSetLength, eventLoopGroup, channelClass), address);
   }
 
   ReconnectingClient(final BackoffFunction backoffFunction,

--- a/folsom/src/test/java/com/spotify/folsom/ExponentialBackoffTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/ExponentialBackoffTest.java
@@ -24,7 +24,7 @@ public class ExponentialBackoffTest {
   public static final double EPSILON = 0.001;
 
   @Test
-  public void testSimple() throws Exception {
+  public void testSimple() {
     int minTime = 10;
     int maxTime = 1000;
     double factor = 2.0;

--- a/folsom/src/test/java/com/spotify/folsom/GetResultTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/GetResultTest.java
@@ -23,7 +23,7 @@ import static org.junit.Assert.assertTrue;
 public class GetResultTest {
 
   @Test(expected = NullPointerException.class)
-  public void testCstrNullValue() throws Exception {
+  public void testCstrNullValue() {
     GetResult.success(null, 123);
   }
 

--- a/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
@@ -170,7 +170,7 @@ public class MemcacheClientBuilderTest {
     EventLoopGroup elg = new NioEventLoopGroup(0, factory);
 
     AsciiMemcacheClient<String> client = MemcacheClientBuilder.newStringClient()
-            .withAddress("127.0.0.1", server.getPort())
+            .withAddress("127.0.0.2", server.getPort())
             .withReplyExecutor(null)
             .withEventLoopGroup(elg)
             .connectAscii();

--- a/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
@@ -152,9 +152,7 @@ public class MemcacheClientBuilderTest {
     client.awaitConnected(10, TimeUnit.SECONDS);
 
     try {
-      assertEquals(MemcacheStatus.OK, client.set("key", "value", 100).toCompletableFuture().get());
-
-      CompletableFuture<Boolean> isInELG = client.get("key").toCompletableFuture()
+      CompletableFuture<Boolean> isInELG = client.set("key", "value", 100).toCompletableFuture()
               .thenApply(r ->
                 Thread.currentThread().getName().startsWith("defaultRawMemcacheClient")
               );
@@ -179,9 +177,7 @@ public class MemcacheClientBuilderTest {
     client.awaitConnected(10, TimeUnit.SECONDS);
 
     try {
-      assertEquals(MemcacheStatus.OK, client.set("key", "value", 100).toCompletableFuture().get());
-
-      CompletableFuture<Boolean> isInELG = client.get("key").toCompletableFuture()
+      CompletableFuture<Boolean> isInELG = client.set("key", "value", 100).toCompletableFuture()
               .thenApply(r ->
                       Thread.currentThread().getName().startsWith("provided_elg")
               );

--- a/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
@@ -17,8 +17,15 @@ package com.spotify.folsom;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
+
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +34,8 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class MemcacheClientBuilderTest {
@@ -51,7 +60,7 @@ public class MemcacheClientBuilderTest {
             .connectAscii();
     try {
       client.awaitConnected(10, TimeUnit.SECONDS);
-      assertEquals(null, client.get("Räksmörgås").toCompletableFuture().get());
+      assertNull(client.get("Räksmörgås").toCompletableFuture().get());
     } finally {
       client.shutdown();
       client.awaitDisconnected(10, TimeUnit.SECONDS);
@@ -66,7 +75,7 @@ public class MemcacheClientBuilderTest {
             .connectAscii();
     try {
       client.awaitConnected(10, TimeUnit.SECONDS);
-      assertEquals(null, client.get("Räksmörgås").toCompletableFuture().get());
+      assertNull(client.get("Räksmörgås").toCompletableFuture().get());
     } finally {
       client.shutdown();
       client.awaitDisconnected(10, TimeUnit.SECONDS);
@@ -127,7 +136,57 @@ public class MemcacheClientBuilderTest {
       assertEquals(
           MemcacheStatus.VALUE_TOO_LARGE,
           client.set("key", "value", 100).toCompletableFuture().get());
-      assertEquals(null, client.get("key").toCompletableFuture().get());
+      assertNull(client.get("key").toCompletableFuture().get());
+    } finally {
+      client.shutdown();
+      client.awaitDisconnected(10, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  public void testShouldExecuteInEventLoopGroup() throws Exception {
+    AsciiMemcacheClient<String> client = MemcacheClientBuilder.newStringClient()
+            .withAddress("127.0.0.1", server.getPort())
+            .withReplyExecutor(null)
+            .connectAscii();
+    client.awaitConnected(10, TimeUnit.SECONDS);
+
+    try {
+      assertEquals(MemcacheStatus.OK, client.set("key", "value", 100).toCompletableFuture().get());
+
+      CompletableFuture<Boolean> isInELG = client.get("key").toCompletableFuture()
+              .thenApply(r ->
+                Thread.currentThread().getName().startsWith("defaultRawMemcacheClient")
+              );
+
+      assertTrue(isInELG.get());
+    } finally {
+      client.shutdown();
+      client.awaitDisconnected(10, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  public void testShouldExecuteInProvidedEventLoopGroup() throws Exception {
+    ThreadFactory factory = new DefaultThreadFactory("provided_elg", true);
+    EventLoopGroup elg = new NioEventLoopGroup(0, factory);
+
+    AsciiMemcacheClient<String> client = MemcacheClientBuilder.newStringClient()
+            .withAddress("127.0.0.1", server.getPort())
+            .withReplyExecutor(null)
+            .withEventLoopGroup(elg)
+            .connectAscii();
+    client.awaitConnected(10, TimeUnit.SECONDS);
+
+    try {
+      assertEquals(MemcacheStatus.OK, client.set("key", "value", 100).toCompletableFuture().get());
+
+      CompletableFuture<Boolean> isInELG = client.get("key").toCompletableFuture()
+              .thenApply(r ->
+                      Thread.currentThread().getName().startsWith("provided_elg")
+              );
+
+      assertTrue(isInELG.get());
     } finally {
       client.shutdown();
       client.awaitDisconnected(10, TimeUnit.SECONDS);

--- a/folsom/src/test/java/com/spotify/folsom/MemcacheClientStressTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/MemcacheClientStressTest.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -139,7 +138,7 @@ public class MemcacheClientStressTest {
   }
 
   @After
-  public void tearDown() throws ExecutionException, InterruptedException, TimeoutException {
+  public void tearDown() throws InterruptedException, TimeoutException {
     client.shutdown();
     daemon.stop();
     workerExecutor.shutdown();

--- a/folsom/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
@@ -95,7 +95,9 @@ public class DefaultRawMemcacheClientTest {
         null,
         3000,
         Charsets.UTF_8,
-        new NoopMetrics(), 1024 * 1024
+        new NoopMetrics(), 1024 * 1024,
+        null,
+        null
     ).toCompletableFuture().get();
 
     DefaultAsciiMemcacheClient<String> asciiClient =
@@ -177,7 +179,8 @@ public class DefaultRawMemcacheClientTest {
 
     final HostAndPort address = HostAndPort.fromParts("127.0.0.1", server.getLocalPort());
     RawMemcacheClient rawClient = DefaultRawMemcacheClient.connect(
-        address, 5000, false, null, 1000, Charsets.UTF_8, new NoopMetrics(), 1024 * 1024)
+        address, 5000, false, null, 1000,
+            Charsets.UTF_8, new NoopMetrics(), 1024 * 1024, null, null)
         .toCompletableFuture().get();
 
     final CompletionStage<?> future = rawClient.send(
@@ -204,7 +207,7 @@ public class DefaultRawMemcacheClientTest {
     final HostAndPort address = HostAndPort.fromParts("127.0.0.10", binaryServer.getPort());
     final RawMemcacheClient rawClient = DefaultRawMemcacheClient.connect(
         address, outstandingRequestLimit, binary, executor, timeoutMillis, Charsets.UTF_8,
-        new NoopMetrics(), maxSetLength).toCompletableFuture().get();
+        new NoopMetrics(), maxSetLength, null, null).toCompletableFuture().get();
 
     try {
       byte[] key = "foo".getBytes(Charsets.UTF_8);
@@ -237,7 +240,7 @@ public class DefaultRawMemcacheClientTest {
     final HostAndPort address = HostAndPort.fromParts("127.0.0.9", asciiServer.getPort());
     final RawMemcacheClient rawClient = DefaultRawMemcacheClient.connect(
         address, outstandingRequestLimit, binary, executor, timeoutMillis, Charsets.UTF_8,
-        new NoopMetrics(), maxSetLength).toCompletableFuture().get();
+        new NoopMetrics(), maxSetLength, null, null).toCompletableFuture().get();
 
     try {
       final GetRequest request =
@@ -263,7 +266,8 @@ public class DefaultRawMemcacheClientTest {
 
     final HostAndPort address = HostAndPort.fromParts("127.0.0.1", server.getLocalPort());
     RawMemcacheClient rawClient = DefaultRawMemcacheClient.connect(
-        address, 5000, false, null, 1000, Charsets.UTF_8, new NoopMetrics(), 1024 * 1024)
+        address, 5000, false, null, 1000,
+            Charsets.UTF_8, new NoopMetrics(), 1024 * 1024, null, null)
         .toCompletableFuture().get();
 
     rawClient.shutdown();
@@ -278,7 +282,7 @@ public class DefaultRawMemcacheClientTest {
 
     final HostAndPort address = HostAndPort.fromParts("127.0.0.1", server.getLocalPort());
     RawMemcacheClient rawClient = DefaultRawMemcacheClient.connect(
-        address, 1, false, null, 1000, Charsets.UTF_8, new NoopMetrics(), 1024 * 1024)
+        address, 1, false, null, 1000, Charsets.UTF_8, new NoopMetrics(), 1024 * 1024, null, null)
         .toCompletableFuture().get();
 
     rawClient.shutdown();
@@ -310,7 +314,7 @@ public class DefaultRawMemcacheClientTest {
 
     final HostAndPort address = HostAndPort.fromParts("127.0.0.1", server.getLocalPort());
     RawMemcacheClient rawClient = DefaultRawMemcacheClient.connect(
-        address, 1, false, null, 1000, Charsets.UTF_8, new NoopMetrics(), 1024 * 1024)
+        address, 1, false, null, 1000, Charsets.UTF_8, new NoopMetrics(), 1024 * 1024, null, null)
         .toCompletableFuture().get();
 
     rawClient.shutdown();
@@ -343,7 +347,9 @@ public class DefaultRawMemcacheClientTest {
           3000,
           charset,
           metrics,
-          1024 * 1024
+          1024 * 1024,
+          null,
+          null
       ).toCompletableFuture().get();
 
       try {

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,11 @@
     <module>folsom-semantic-metrics</module>
   </modules>
 
-  <distributionManagement>
-    <repository>
-      <id>arquitectura.releases</id>
-      <name>Nexus Arquitectura</name>
-      <url>http://git.ml.com:8081/nexus/content/repositories/releases</url>
-    </repository>
-  </distributionManagement>
+  <scm>
+    <connection>scm:git:https://github.com/spotify/folsom.git</connection>
+    <developerConnection>scm:git:git@github.com:spotify/folsom.git</developerConnection>
+    <url>scm:https://github.com/spotify/folsom/</url>
+  </scm>
 
   <licenses>
     <license>
@@ -59,6 +57,17 @@
     </developer>
   </developers>
 
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
   <build>
     <pluginManagement>
       <plugins>
@@ -70,20 +79,6 @@
             <source>1.8</source>
             <target>1.8</target>
           </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-          <executions>
-            <execution>
-              <id>default-deploy</id>
-              <phase>deploy</phase>
-              <goals>
-                <goal>deploy</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -168,6 +163,19 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.3</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
   <profiles>
     <!-- only run checkstyle plugin on jdk versions < 1.9 -->

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,13 @@
     <module>folsom-semantic-metrics</module>
   </modules>
 
-  <scm>
-    <connection>scm:git:https://github.com/spotify/folsom.git</connection>
-    <developerConnection>scm:git:git@github.com:spotify/folsom.git</developerConnection>
-    <url>scm:https://github.com/spotify/folsom/</url>
-  </scm>
+  <distributionManagement>
+    <repository>
+      <id>arquitectura.releases</id>
+      <name>Nexus Arquitectura</name>
+      <url>http://git.ml.com:8081/nexus/content/repositories/releases</url>
+    </repository>
+  </distributionManagement>
 
   <licenses>
     <license>
@@ -57,17 +59,6 @@
     </developer>
   </developers>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <build>
     <pluginManagement>
       <plugins>
@@ -79,6 +70,20 @@
             <source>1.8</source>
             <target>1.8</target>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+          <executions>
+            <execution>
+              <id>default-deploy</id>
+              <phase>deploy</phase>
+              <goals>
+                <goal>deploy</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -163,19 +168,6 @@
         </plugin>
       </plugins>
     </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-    </plugins>
   </build>
   <profiles>
     <!-- only run checkstyle plugin on jdk versions < 1.9 -->


### PR DESCRIPTION
I've added a few changes mainly regarding Netty behaviour:

- Added support to specify an existing EventLoopGroup to reuse.
- Added support for Epoll ELG and Channel.
- Allow to execute callbacks in same ELG threads, specifying a null executor in builder, for efficient execution of very short lived tasks.
- Dependencies upgrade.
- Reduce memory footprint via AtomicReferenceFieldUpdater usage