### PR TITLE
Decrement pending request counter when handling VALUE_TOO_LARGE

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -214,6 +214,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
       SetRequest setRequest = (SetRequest) request;
       byte[] value = setRequest.getValue();
       if (value.length > maxSetLength) {
+        pendingCounter.decrementAndGet();
         return (CompletionStage<T>) onExecutor(
                 CompletableFuture.completedFuture(MemcacheStatus.VALUE_TOO_LARGE));
       }


### PR DESCRIPTION
Pending request counter is not decremented when handling VALUE_TOO_LARGE.  Fixing #91