### PR TITLE
Build on OpenJDK11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,10 @@ secure: "H4tUL1Greyj588Kb1/FnRapFT/57KaApQYAZx2KRORkddYSzPq2tovI1S8AnqzCHpVtfjin
 
 language: java
 
-
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      jdk: oraclejdk8
-    - os: linux
-      dist: trusty
-      jdk: oraclejdk9
+jdk:
+  - oraclejdk8
+  - oraclejdk9
+  - openjdk11
 
 install:
   - mvn install -DskipTests=true -Dgpg.skip=true

--- a/folsom/pom.xml
+++ b/folsom/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <artifactId>mockito-core</artifactId>
       <groupId>org.mockito</groupId>
-      <version>2.8.47</version>
+      <version>2.21.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Also removes the build matrix as that should no longer be necessary.