### PR TITLE
fix flaky "ShouldExecuteIn" tests

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -46,7 +46,6 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
@@ -308,9 +307,9 @@ public class MemcacheClientBuilder<V> {
    *
    * If null is specified, replies will be executed on EventLoopGroup directly.
    *
-   * <b>Note:</b> Calling non-async methods on the {@link CompletionStage}s returned by
-   * {@link MemcacheClient} that have already completed will cause the supplied function
-   * to be executed directly on the calling thread.
+   * <b>Note:</b> Calling non-async methods on the {@link java.util.concurrent.CompletionStage}s
+   * returned by {@link MemcacheClient} that have already completed will cause the supplied
+   * function to be executed directly on the calling thread.
    *
    * @param executor the executor to use.
    * @return itself

--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -46,6 +46,7 @@ import java.io.Serializable;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
@@ -306,6 +307,11 @@ public class MemcacheClientBuilder<V> {
    * async mode with one thread per processor.
    *
    * If null is specified, replies will be executed on EventLoopGroup directly.
+   *
+   * <b>Note:</b> Calling non-async methods on the {@link CompletionStage}s returned by
+   * {@link MemcacheClient} that have already completed will cause the supplied function
+   * to be executed directly on the calling thread.
+   *
    * @param executor the executor to use.
    * @return itself
    */

--- a/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
@@ -185,7 +185,8 @@ public class MemcacheClientBuilderTest {
    *
    * Attempts to defeat the inherent raciness by trying until successful.
    */
-  private void assertExecutesOnThread(AsciiMemcacheClient<String> client, String expectedThreadNamePrefix)
+  private void assertExecutesOnThread(AsciiMemcacheClient<String> client,
+      String expectedThreadNamePrefix)
       throws InterruptedException, ExecutionException, TimeoutException {
 
     final long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);


### PR DESCRIPTION
* `testShouldExecuteInEventLoopGroup`
* `testShouldExecuteInProvidedEventLoopGroup`

A bit icky, but unless we supply our own CF/CS there's just no guarantee that the supplied callback will always execute on the upstream executor.