### PR TITLE
Support configurable batch size when creating clients

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -278,22 +278,20 @@ public class MemcacheClientBuilder<V> {
   }
 
   /**
-   * Specify the maximum number of operations that will be batched together in one network
-   * request.
+   * Specify the maximum number of operations that will be batched together in one network request.
    *
-   * If the client's batch-size is larger than your memcached server's value, you may experience
-   * an increase in `conn_yields` on your memcached server's stats...which indicates your server
-   * is switching to other I/O connections during the batch request to not starve other
-   * connections.
+   * <p>If the client's batch-size is larger than your memcached server's value, you may experience
+   * an increase in `conn_yields` on your memcached server's stats...which indicates your server is
+   * switching to other I/O connections during the batch request to not starve other connections.
    *
-   * If this value is too low, your will make more network requests per operation, thus reducing
+   * <p>If this value is too low, your will make more network requests per operation, thus reducing
    * your server's overall throughput.
    *
-   * The optimal value should be matched to your workload and roughly the same value as your
+   * <p>The optimal value should be matched to your workload and roughly the same value as your
    * memcached server's `-R` argument, which defaults to 20.
    *
-   * @param batchSize the maximum number of operations per batched client request.
-   *                  Default is {@value Settings#DEFAULT_BATCH_SIZE}.
+   * @param batchSize the maximum number of operations per batched client request. Default is
+   *     {@value Settings#DEFAULT_BATCH_SIZE}.
    * @return itself
    */
   public MemcacheClientBuilder<V> withRequestBatchSize(final int batchSize) {

--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -16,6 +16,7 @@
 
 package com.spotify.folsom;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.spotify.folsom.client.MemcacheEncoder.MAX_KEY_LEN;
@@ -295,6 +296,7 @@ public class MemcacheClientBuilder<V> {
    * @return itself
    */
   public MemcacheClientBuilder<V> withRequestBatchSize(final int batchSize) {
+    checkArgument(batchSize > 0, "batch size must be > 0");
     this.batchSize = batchSize;
     return this;
   }

--- a/folsom/src/main/java/com/spotify/folsom/Settings.java
+++ b/folsom/src/main/java/com/spotify/folsom/Settings.java
@@ -1,0 +1,8 @@
+package com.spotify.folsom;
+
+public class Settings {
+    /**
+     * Note that the default Memcached server batch size is 20. See Memcached server documentation on "-R" option.
+     */
+    public static final int DEFAULT_BATCH_SIZE = 64;
+}

--- a/folsom/src/main/java/com/spotify/folsom/Settings.java
+++ b/folsom/src/main/java/com/spotify/folsom/Settings.java
@@ -1,8 +1,9 @@
 package com.spotify.folsom;
 
 public class Settings {
-    /**
-     * Note that the default Memcached server batch size is 20. See Memcached server documentation on "-R" option.
-     */
-    public static final int DEFAULT_BATCH_SIZE = 64;
+  /**
+   * Note that the default Memcached server batch size is 20. See Memcached server documentation on
+   * "-R" option.
+   */
+  public static final int DEFAULT_BATCH_SIZE = 64;
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/BatchFlusher.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/BatchFlusher.java
@@ -64,7 +64,8 @@ class BatchFlusher {
       };
 
   /**
-   * Deprecated - use {@link BatchFlusher#BatchFlusher(Channel, int)} with explicit maxPending parameter instead.
+   * Deprecated - use {@link BatchFlusher#BatchFlusher(Channel, int)} with explicit maxPending
+   * parameter instead.
    */
   @Deprecated
   public BatchFlusher(final Channel channel) {

--- a/folsom/src/main/java/com/spotify/folsom/client/BatchFlusher.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/BatchFlusher.java
@@ -15,6 +15,7 @@
  */
 package com.spotify.folsom.client;
 
+import com.spotify.folsom.Settings;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -25,8 +26,6 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
  * into fewer syscalls.
  */
 class BatchFlusher {
-
-  private static final int DEFAULT_MAX_PENDING = 64;
 
   private final Channel channel;
   private final EventLoop eventLoop;
@@ -64,8 +63,12 @@ class BatchFlusher {
         }
       };
 
+  /**
+   * Deprecated - use {@link BatchFlusher#BatchFlusher(Channel, int)} with explicit maxPending parameter instead.
+   */
+  @Deprecated
   public BatchFlusher(final Channel channel) {
-    this(channel, DEFAULT_MAX_PENDING);
+    this(channel, Settings.DEFAULT_BATCH_SIZE);
   }
 
   public BatchFlusher(final Channel channel, final int maxPending) {

--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -97,6 +97,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
   public static CompletionStage<RawMemcacheClient> connect(
       final HostAndPort address,
       final int outstandingRequestLimit,
+      final int batchSize,
       final boolean binary,
       final Executor executor,
       final long timeoutMillis,
@@ -154,6 +155,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
                         address,
                         future.channel(),
                         outstandingRequestLimit,
+                        batchSize,
                         executor,
                         timeoutMillis,
                         metrics,
@@ -176,6 +178,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
       final HostAndPort address,
       final Channel channel,
       final int outstandingRequestLimit,
+      final int batchSize,
       final Executor executor,
       final long timeoutMillis,
       final Metrics metrics,
@@ -185,7 +188,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
     this.timeoutMillis = timeoutMillis;
     this.maxSetLength = maxSetLength;
     this.channel = checkNotNull(channel, "channel");
-    this.flusher = new BatchFlusher(channel);
+    this.flusher = new BatchFlusher(channel, batchSize);
     this.outstandingRequestLimit = outstandingRequestLimit;
 
     GLOBAL_CONNECTION_COUNT.incrementAndGet();

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -63,6 +63,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
       final ScheduledExecutorService scheduledExecutorService,
       final HostAndPort address,
       final int outstandingRequestLimit,
+      final int batchSize,
       final boolean binary,
       final Authenticator authenticator,
       final Executor executor,
@@ -79,6 +80,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
             DefaultRawMemcacheClient.connect(
                 address,
                 outstandingRequestLimit,
+                batchSize,
                 binary,
                 executor,
                 timeoutMillis,

--- a/folsom/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
@@ -57,6 +57,8 @@ import org.junit.Test;
 
 public class DefaultRawMemcacheClientTest {
 
+  private static final int BATCH_SIZE = 20;
+
   private MemcachedServer server;
 
   @Before
@@ -77,6 +79,7 @@ public class DefaultRawMemcacheClientTest {
         DefaultRawMemcacheClient.connect(
                 HostAndPort.fromParts(server.getHost(), server.getPort()),
                 5000,
+                BATCH_SIZE,
                 false,
                 null,
                 3000,
@@ -176,6 +179,7 @@ public class DefaultRawMemcacheClientTest {
         DefaultRawMemcacheClient.connect(
                 address,
                 5000,
+                BATCH_SIZE,
                 false,
                 null,
                 1000,
@@ -214,6 +218,7 @@ public class DefaultRawMemcacheClientTest {
         DefaultRawMemcacheClient.connect(
                 address,
                 outstandingRequestLimit,
+                BATCH_SIZE,
                 binary,
                 executor,
                 timeoutMillis,
@@ -257,6 +262,7 @@ public class DefaultRawMemcacheClientTest {
         DefaultRawMemcacheClient.connect(
                 address,
                 outstandingRequestLimit,
+                BATCH_SIZE,
                 binary,
                 executor,
                 timeoutMillis,
@@ -292,6 +298,7 @@ public class DefaultRawMemcacheClientTest {
         DefaultRawMemcacheClient.connect(
                 address,
                 5000,
+                BATCH_SIZE,
                 false,
                 null,
                 1000,
@@ -318,6 +325,7 @@ public class DefaultRawMemcacheClientTest {
         DefaultRawMemcacheClient.connect(
                 address,
                 1,
+                BATCH_SIZE,
                 false,
                 null,
                 1000,
@@ -365,6 +373,7 @@ public class DefaultRawMemcacheClientTest {
         DefaultRawMemcacheClient.connect(
                 address,
                 1,
+                BATCH_SIZE,
                 false,
                 null,
                 1000,
@@ -404,6 +413,7 @@ public class DefaultRawMemcacheClientTest {
           DefaultRawMemcacheClient.connect(
                   HostAndPort.fromParts("127.0.0.12", port),
                   5000,
+                  BATCH_SIZE,
                   false,
                   null,
                   3000,


### PR DESCRIPTION
added `withRequestBatchSize(int)` method to MemcacheClientBuilder.

this allows fine-tuning performance for high-throughput services.
we have been using this fix in highly loaded services in prod env
for years (our local clone of this library).

extracted default batch size constant from BatchFlusher class
to Settings because it was not visible to code outside of that package
and it was required in MemcacheClientBuilder