### PR TITLE
more precise timeouts handling plus counting full request time

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -18,7 +18,6 @@ package com.spotify.folsom.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -72,9 +71,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
 
   private static final AtomicInteger GLOBAL_CONNECTION_COUNT = new AtomicInteger();
   private static final double NANOS_IN_MILLIS = 1000000.0;
-  /**
-   * how often to check if the request has timed out
-   */
+  /** how often to check if the request has timed out */
   private static final int TIMEOUT_POLL_INTERVAL_MILLIS = 10;
 
   private final Logger log = LoggerFactory.getLogger(DefaultRawMemcacheClient.class);

--- a/folsom/src/main/java/com/spotify/folsom/client/Request.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/Request.java
@@ -28,9 +28,11 @@ import java.util.concurrent.CompletableFuture;
 
 public abstract class Request<V> extends CompletableFuture<V> {
   protected final byte[] key;
+  protected final long createdNanos;
 
   protected Request(byte[] key) {
     this.key = key;
+    createdNanos = System.nanoTime();
   }
 
   protected static ByteBuf toBuffer(final ByteBufAllocator alloc, ByteBuffer dst) {
@@ -39,6 +41,10 @@ public abstract class Request<V> extends CompletableFuture<V> {
 
   public byte[] getKey() {
     return key;
+  }
+
+  public long getCreatedNanos() {
+    return createdNanos;
   }
 
   public abstract ByteBuf writeRequest(final ByteBufAllocator alloc, ByteBuffer dst);

--- a/folsom/src/main/java/com/spotify/folsom/client/TimeoutChecker.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/TimeoutChecker.java
@@ -18,35 +18,25 @@ package com.spotify.folsom.client;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A utility for checking whether some state has changed within a specified timout. Could be used to
- * verify that the head of a request queue changes quickly enough, indicating forward progress.
+ * A utility for checking whether a {@link Request} has timed out.
  */
-class TimeoutChecker<T> {
+class TimeoutChecker {
 
   private final long timeoutNanos;
 
-  private T pending;
-  private long timestamp;
-
-  public TimeoutChecker(final TimeUnit unit, final long timeout) {
-    this.timeoutNanos = unit.toNanos(timeout);
+  private TimeoutChecker(final TimeUnit unit, final long timeout) {
+    timeoutNanos = unit.toNanos(timeout);
   }
 
-  public boolean check(final T current) {
-    final long nowNanos = System.nanoTime();
-
-    // New task?
-    if (current != pending) {
-      pending = current;
-      timestamp = nowNanos;
-      return false;
-    }
-
-    // Timed out?
-    return nowNanos - timestamp > timeoutNanos;
+  public boolean check(final Request<?> request) {
+    return elapsedNanos(request) > timeoutNanos;
   }
 
-  public static <T> TimeoutChecker<T> create(final TimeUnit unit, final long timeout) {
-    return new TimeoutChecker<>(unit, timeout);
+  public long elapsedNanos(final Request<?> request) {
+    return System.nanoTime() - request.getCreatedNanos();
+  }
+
+  public static TimeoutChecker create(final TimeUnit unit, final long timeout) {
+    return new TimeoutChecker(unit, timeout);
   }
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/TimeoutChecker.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/TimeoutChecker.java
@@ -17,9 +17,7 @@ package com.spotify.folsom.client;
 
 import java.util.concurrent.TimeUnit;
 
-/**
- * A utility for checking whether a {@link Request} has timed out.
- */
+/** A utility for checking whether a {@link Request} has timed out. */
 class TimeoutChecker {
 
   private final long timeoutNanos;

--- a/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/MemcacheClientBuilderTest.java
@@ -108,7 +108,7 @@ public class MemcacheClientBuilderTest {
     AsciiMemcacheClient<String> client =
         MemcacheClientBuilder.newStringClient()
             .withAddress(server.getHost(), server.getPort())
-            .withMaxOutstandingRequests(100)
+            .withMaxOutstandingRequests(10)
             .connectAscii();
     client.awaitConnected(10, TimeUnit.SECONDS);
 

--- a/folsom/src/test/java/com/spotify/folsom/client/TimeoutCheckerTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/TimeoutCheckerTest.java
@@ -15,36 +15,82 @@
  */
 package com.spotify.folsom.client;
 
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.concurrent.TimeUnit;
-import org.junit.Test;
-
 public class TimeoutCheckerTest {
 
-  final TimeoutChecker<String> sut = TimeoutChecker.create(TimeUnit.MILLISECONDS, 100);
+  private TimeoutChecker sut = TimeoutChecker.create(TimeUnit.MILLISECONDS, 100);
+  private Request<Integer> request;
 
   @Test
-  public void testTimeout() throws Exception {
-    assertFalse(sut.check("foo"));
-    assertFalse(sut.check("foo"));
-    Thread.sleep(200);
-    assertTrue(sut.check("foo"));
+  public void testTimeout0ms() throws Exception {
+    request = new DummyRequest();
+    assertFalse(sut.check(request));
   }
 
   @Test
-  public void testNullNoTimeout() throws Exception {
-    assertFalse(sut.check("foo"));
-    assertFalse(sut.check(null));
+  public void testTimeout95ms() throws Exception {
+    request = new DummyRequest();
+    Thread.sleep(95);
+    assertFalse(sut.check(request));
   }
 
   @Test
-  public void testNewTaskNoTimeout() throws Exception {
-    assertFalse(sut.check("foo"));
-    Thread.sleep(200);
-    assertFalse(sut.check("bar"));
-    Thread.sleep(200);
-    assertFalse(sut.check("baz"));
+  public void testTimeout101ms() throws Exception {
+    request = new DummyRequest();
+    Thread.sleep(101);
+    assertTrue(sut.check(request));
+  }
+
+  @Test
+  public void testTimeoutSeconds() throws Exception {
+    sut = TimeoutChecker.create(TimeUnit.SECONDS, 100);
+    request = new DummyRequest();
+    Thread.sleep(1);
+    assertFalse(sut.check(request));
+  }
+
+  @Test
+  public void testElapsedLessThanOne() throws InterruptedException {
+    request = new DummyRequest();
+    assertTrue(sut.elapsedNanos(request) <
+            TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void testElapsedMoreThanOne() throws InterruptedException {
+    request = new DummyRequest();
+    Thread.sleep(1);
+    assertTrue(sut.elapsedNanos(request) >
+            TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS));
+  }
+
+
+  class DummyRequest extends Request<Integer> {
+
+    DummyRequest() {
+      super("foobar".getBytes(Charset.defaultCharset()));
+    }
+
+    @Override
+    public ByteBuf writeRequest(final ByteBufAllocator alloc, final ByteBuffer dst) {
+      return null;
+    }
+
+    @Override
+    public void handle(final Object response) throws IOException {
+
+    }
   }
 }

--- a/folsom/src/test/java/com/spotify/folsom/client/TimeoutCheckerTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/TimeoutCheckerTest.java
@@ -15,18 +15,16 @@
  */
 package com.spotify.folsom.client;
 
-import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class TimeoutCheckerTest {
 
@@ -64,18 +62,15 @@ public class TimeoutCheckerTest {
   @Test
   public void testElapsedLessThanOne() throws InterruptedException {
     request = new DummyRequest();
-    assertTrue(sut.elapsedNanos(request) <
-            TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS));
+    assertTrue(sut.elapsedNanos(request) < TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS));
   }
 
   @Test
   public void testElapsedMoreThanOne() throws InterruptedException {
     request = new DummyRequest();
     Thread.sleep(1);
-    assertTrue(sut.elapsedNanos(request) >
-            TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS));
+    assertTrue(sut.elapsedNanos(request) > TimeUnit.NANOSECONDS.convert(1, TimeUnit.MILLISECONDS));
   }
-
 
   class DummyRequest extends Request<Integer> {
 
@@ -89,8 +84,6 @@ public class TimeoutCheckerTest {
     }
 
     @Override
-    public void handle(final Object response) throws IOException {
-
-    }
+    public void handle(final Object response) throws IOException {}
   }
 }


### PR DESCRIPTION
this change enables much more precise handling of request timeouts.

we have been using this in highly loaded services
with pretty low timeout setting (well under one second).

changed `TimeoutChecker` to use the time request was created.
changed `DefaultRawMemcacheClient` to poll for timeout every 10ms.
changed single timeout logging from error to info level. this helps with using the library in very high throughput services where you don't necessarily want to log every connection issue as an error.

added `createdNanos` to `Request` object