### PR TITLE
more precise timeouts handling (10 ms resolution instead of ~second)

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/BatchFlusher.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/BatchFlusher.java
@@ -15,7 +15,6 @@
  */
 package com.spotify.folsom.client;
 
-import com.spotify.folsom.Settings;
 import io.netty.channel.Channel;
 import io.netty.channel.EventLoop;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;

--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -18,7 +18,6 @@ package com.spotify.folsom.client;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -72,9 +71,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
 
   private static final AtomicInteger GLOBAL_CONNECTION_COUNT = new AtomicInteger();
 
-  /**
-   * how often to check if a request timed out, in msec.
-   */
+  /** how often to check if a request timed out, in msec. */
   private final int DEFAULT_TIMEOUT_POLL_INTERVAL_MILLIS = 10;
 
   private final Logger log = LoggerFactory.getLogger(DefaultRawMemcacheClient.class);

--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -72,6 +72,11 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
 
   private static final AtomicInteger GLOBAL_CONNECTION_COUNT = new AtomicInteger();
 
+  /**
+   * how often to check if a request timed out, in msec.
+   */
+  private final int DEFAULT_TIMEOUT_POLL_INTERVAL_MILLIS = 10;
+
   private final Logger log = LoggerFactory.getLogger(DefaultRawMemcacheClient.class);
 
   private final AtomicInteger pendingCounter = new AtomicInteger();
@@ -292,7 +297,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
     private final Future<?> timeoutCheckTask;
 
     ConnectionHandler() {
-      final long pollIntervalMillis = Math.min(timeoutMillis, SECONDS.toMillis(1));
+      final long pollIntervalMillis = DEFAULT_TIMEOUT_POLL_INTERVAL_MILLIS;
       timeoutCheckTask =
           channel
               .eventLoop()


### PR DESCRIPTION
this change enables much more precise handling of request timeouts.