### PR TITLE
reduce logging level for timeouts

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -303,7 +303,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
                       return;
                     }
                     if (timeoutChecker.check(head)) {
-                      log.error("Request timeout: {} {}", channel, head);
+                      log.warn("Request timeout: {} {}", channel, head);
                       DefaultRawMemcacheClient.this.setDisconnected("Timeout");
                     }
                   },

--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -303,7 +303,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
                       return;
                     }
                     if (timeoutChecker.check(head)) {
-                      log.warn("Request timeout: {} {}", channel, head);
+                      log.info("Request timeout: {} {}", channel, head);
                       DefaultRawMemcacheClient.this.setDisconnected("Timeout");
                     }
                   },


### PR DESCRIPTION
this change is related to https://github.com/spotify/folsom/issues/67

the motivation for this change is that some users may have external
retriers around clients, like this Memcached one.
the library ideally should throw an exception on timeout and
let users deal with it however they see fit - it may be logging,
retrying or falling back to another solution.
when the library logs an error in this case, this makes logging
noisy, which may distort operational metrics in a
typical prod environment.