### PR TITLE
Change OpCode to an enum

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/OpCode.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/OpCode.java
@@ -16,75 +16,92 @@
 
 package com.spotify.folsom.client;
 
-public final class OpCode {
+import java.util.EnumSet;
 
-  private OpCode() {}
+public enum OpCode {
+  GET(0x00),
+  SET(0x01),
+  ADD(0x02),
+  REPLACE(0x03),
+  DELETE(0x04),
+  INCREMENT(0x05),
+  DECREMENT(0x06),
+  QUIT(7),
+  FLUSH(0x08),
+  GETQ(0x09),
+  NOOP(0x0a),
 
-  public static final byte GET = 0x00;
-  public static final byte SET = 0x01;
-  public static final byte ADD = 0x02;
-  public static final byte REPLACE = 0x03;
-  public static final byte DELETE = 0x04;
-  public static final byte INCREMENT = 0x05;
-  public static final byte DECREMENT = 0x06;
-  public static final int QUIT = 7;
-  public static final byte FLUSH = 0x08;
-  public static final byte GETQ = 0x09;
-  public static final byte NOOP = 0x0a;
+  VERSION(0x0b),
+  GETK(0x0c),
+  GETKQ(0x0d),
+  APPEND(0x0e),
+  PREPEND(0x0f),
+  STAT(0x10),
+  SETQ(0x11),
+  ADDQ(0x12),
+  REPLACEQ(0x13),
+  DELETEQ(0x14),
+  INCREMENTQ(0x15),
+  DECREMENTQ(0x16),
+  QUITQ(0x17),
+  FLUSHQ(0x18),
 
-  public static final int VERSION = 0x0b;
-  public static final int GETK = 0x0c;
-  public static final int GETKQ = 0x0d;
-  public static final byte APPEND = 0x0e;
-  public static final byte PREPEND = 0x0f;
-  public static final byte STAT = 0x10;
-  public static final int SETQ = 0x11;
-  public static final int ADDQ = 0x12;
-  public static final int REPLACEQ = 0x13;
-  public static final int DELETEQ = 0x14;
-  public static final int INCREMENTQ = 0x15;
-  public static final int DECREMENTQ = 0x16;
-  public static final int QUITQ = 0x17;
-  public static final int FLUSHQ = 0x18;
+  APPENDQ(0x19),
+  PREPANDQ(0x1a),
+  VERBOSITY(0x1b),
+  TOUCH(0x1c),
+  GAT(0x1d),
+  GATQ(0x1e),
+  SASL_LIST_MECHS(0x20),
+  SASL_AUTH(0x21),
+  SASL_STEP(0x22),
 
-  public static final int APPENDQ = 0x19;
-  public static final int PREPANDQ = 0x1a;
-  public static final int VERBOSITY = 0x1b;
-  public static final byte TOUCH = 0x1c;
-  public static final int GAT = 0x1d;
-  public static final int GATQ = 0x1e;
-  public static final int SASL_LIST_MECHS = 0x20;
-  public static final byte SASL_AUTH = 0x21;
-  public static final int SASL_STEP = 0x22;
+  RGET(0x30),
+  RSET(0x31),
+  RSETQ(0x32),
+  RAPPEND(0x33),
+  RAPPENDQ(0x34),
+  RPREPEND(0x35),
+  RPREPENDQ(0x36),
+  RDELETE(0x37),
+  RDELETEQ(0x38),
+  RINCR(0x39),
+  RINCRQ(0x3a),
+  RDECR(0x3b),
+  RDECRQ(0x3c),
 
-  public static final int RGET = 0x30;
-  public static final int RSET = 0x31;
-  public static final int RSETQ = 0x32;
-  public static final int RAPPEND = 0x33;
-  public static final int RAPPENDQ = 0x34;
-  public static final int RPREPEND = 0x35;
-  public static final int RPREPENDQ = 0x36;
-  public static final int RDELETE = 0x37;
-  public static final int RDELETEQ = 0x38;
-  public static final int RINCR = 0x39;
-  public static final int RINCRQ = 0x3a;
-  public static final int RDECR = 0x3b;
-  public static final int RDECRQ = 0x3c;
+  SET_VBUCKET(0x3d),
+  GET_VBUCKET(0x3e),
+  DEL_VBUCKET(0x3f),
 
-  public static final int SET_VBUCKET = 0x3d;
-  public static final int GET_VBUCKET = 0x3e;
-  public static final int DEL_VBUCKET = 0x3f;
+  TAP_MUTATION(0x41),
+  TAP_DELETE(0x42),
+  TAP_FLUSH(0x43),
+  TAP_OPAQUE(0x44),
+  TAP_VBUCKET_SET(0x45),
+  TAP_CHECKPOINT_START(0x46),
+  TAP_CHECKPOINT_END(0x47);
 
-  public static final int TAP_CONNECT = 0x40;
-  public static final int TAP_MUTATION = 0x41;
-  public static final int TAP_DELETE = 0x42;
-  public static final int TAP_FLUSH = 0x43;
-  public static final int TAP_OPAQUE = 0x44;
-  public static final int TAP_VBUCKET_SET = 0x45;
-  public static final int TAP_CHECKPOINT_START = 0x46;
-  public static final int TAP_CHECKPOINT_END = 0x47;
+  // quick lookup by value
+  private static final OpCode[] BY_VALUE = new OpCode[TAP_CHECKPOINT_END.opcode + 1];
 
-  public static byte getKind(final byte opcode) {
+  static {
+    final EnumSet<OpCode> all = EnumSet.allOf(OpCode.class);
+    all.stream().forEach(opCode -> BY_VALUE[opCode.opcode] = opCode);
+  }
+
+  public static OpCode of(final byte value) {
+    if (value >= 0 && value < BY_VALUE.length) {
+      final OpCode opCode = BY_VALUE[value];
+      if (opCode != null) {
+        return opCode;
+      }
+    }
+
+    throw new IllegalArgumentException("Unknown opcode: " + value);
+  }
+
+  public static OpCode getKind(final OpCode opcode) {
     switch (opcode) {
       case GET:
       case GETQ:
@@ -100,5 +117,15 @@ public final class OpCode {
       default:
         return opcode;
     }
+  }
+
+  private final byte opcode;
+
+  OpCode(final int opcode) {
+    this.opcode = (byte) opcode;
+  }
+
+  public byte value() {
+    return opcode;
   }
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/BinaryMemcacheDecoder.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/BinaryMemcacheDecoder.java
@@ -48,7 +48,7 @@ public class BinaryMemcacheDecoder extends ByteToMessageDecoder {
         throw fail(buf, String.format("Invalid magic number: 0x%2x", magicNumber));
       }
 
-      final int opcode = buf.readByte(); // byte 1
+      final OpCode opcode = OpCode.of(buf.readByte()); // byte 1
       final int keyLength = buf.readUnsignedShort(); // byte 2-3
       final int extrasLength = buf.readUnsignedByte(); // byte 4
       buf.skipBytes(1);
@@ -93,10 +93,10 @@ public class BinaryMemcacheDecoder extends ByteToMessageDecoder {
           replies = new BinaryResponse();
         } else {
           // Skip end packet
-          replies.add(new ResponsePacket((byte) opcode, status, opaque, cas, keyBytes, valueBytes));
+          replies.add(new ResponsePacket(opcode, status, opaque, cas, keyBytes, valueBytes));
         }
       } else {
-        replies.add(new ResponsePacket((byte) opcode, status, opaque, cas, keyBytes, valueBytes));
+        replies.add(new ResponsePacket(opcode, status, opaque, cas, keyBytes, valueBytes));
         if ((opaque & 0xFF) == 0) {
           out.add(replies);
           replies = new BinaryResponse();

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/BinaryRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/BinaryRequest.java
@@ -17,6 +17,7 @@
 package com.spotify.folsom.client.binary;
 
 import com.spotify.folsom.client.AbstractRequest;
+import com.spotify.folsom.client.OpCode;
 import com.spotify.folsom.guava.HostAndPort;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -36,14 +37,14 @@ public abstract class BinaryRequest<V> extends AbstractRequest<V> {
 
   public void writeHeader(
       final ByteBuffer dst,
-      final byte opCode,
+      final OpCode opCode,
       final int extraLength,
       final int valueLength,
       final long cas) {
     int keyLength = key.length;
 
     dst.put(MAGIC_NUMBER);
-    dst.put(opCode);
+    dst.put(opCode.value());
     dst.putShort((short) keyLength); // byte 2-3
     dst.put((byte) extraLength); // byte 4
     dst.put((byte) 0);

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/DefaultBinaryMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/DefaultBinaryMemcacheClient.java
@@ -104,7 +104,7 @@ public class DefaultBinaryMemcacheClient<V> implements BinaryMemcacheClient<V> {
   }
 
   private CompletionStage<MemcacheStatus> setInternal(
-      final byte opcode, final String key, final V value, final int ttl) {
+      final OpCode opcode, final String key, final V value, final int ttl) {
     return casSetInternal(opcode, key, value, ttl, 0);
   }
 
@@ -127,7 +127,7 @@ public class DefaultBinaryMemcacheClient<V> implements BinaryMemcacheClient<V> {
   }
 
   private CompletionStage<MemcacheStatus> casSetInternal(
-      final byte opcode, final String key, final V value, final int ttl, final long cas) {
+      final OpCode opcode, final String key, final V value, final int ttl, final long cas) {
     checkNotNull(value);
 
     final byte[] valueBytes = valueTranscoder.encode(value);
@@ -171,7 +171,7 @@ public class DefaultBinaryMemcacheClient<V> implements BinaryMemcacheClient<V> {
   }
 
   private CompletionStage<GetResult<V>> getInternal(final String key, final int ttl) {
-    final byte opCode = ttl > -1 ? OpCode.GAT : OpCode.GET;
+    final OpCode opCode = ttl > -1 ? OpCode.GAT : OpCode.GET;
     GetRequest request = new GetRequest(encodeKey(key, charset, maxKeyLength), opCode, ttl);
     final CompletionStage<GetResult<byte[]>> future = rawMemcacheClient.send(request);
     metrics.measureGetFuture(future);
@@ -272,7 +272,7 @@ public class DefaultBinaryMemcacheClient<V> implements BinaryMemcacheClient<V> {
   }
 
   private CompletionStage<Long> incrInternal(
-      final byte opcode, final String key, final long by, final long initial, final int ttl) {
+      final OpCode opcode, final String key, final long by, final long initial, final int ttl) {
 
     final CompletionStage<Long> future =
         rawMemcacheClient.send(

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/GetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/GetRequest.java
@@ -30,10 +30,10 @@ import java.nio.ByteBuffer;
 
 public class GetRequest extends BinaryRequest<GetResult<byte[]>>
     implements com.spotify.folsom.client.GetRequest {
-  private final byte opcode;
+  private final OpCode opcode;
   private final int ttl;
 
-  public GetRequest(final byte[] key, final byte opcode, final int ttl) {
+  public GetRequest(final byte[] key, final OpCode opcode, final int ttl) {
     super(key);
     this.opcode = checkNotNull(opcode, "opcode");
     this.ttl = checkNotNull(ttl, "ttl");

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/IncrRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/IncrRequest.java
@@ -18,6 +18,7 @@ package com.spotify.folsom.client.binary;
 
 import com.google.common.primitives.Longs;
 import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.client.OpCode;
 import com.spotify.folsom.client.Utils;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
@@ -26,13 +27,13 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 public class IncrRequest extends BinaryRequest<Long> {
-  private final byte opcode;
+  private final OpCode opcode;
   private final long by;
   private final long initial;
   private final int ttl;
 
   public IncrRequest(
-      final byte[] key, final byte opcode, final long by, final long initial, final int ttl) {
+      final byte[] key, final OpCode opcode, final long by, final long initial, final int ttl) {
     super(key);
     this.opcode = opcode;
     this.by = by;

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/MultigetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/MultigetRequest.java
@@ -75,7 +75,7 @@ public class MultigetRequest extends BinaryRequest<List<GetResult<byte[]>>>
       final int opaque = multigetOpaque | --sequenceNumber;
 
       dst.put(MAGIC_NUMBER);
-      dst.put(sequenceNumber == 0 ? OpCode.GET : OpCode.GETQ);
+      dst.put(sequenceNumber == 0 ? OpCode.GET.value() : OpCode.GETQ.value());
       dst.putShort((short) keyLength); // byte 2-3
       dst.put((byte) extrasLength); // byte 4
       dst.put((byte) 0); // byte 5-7, Data type, Reserved

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/NoopRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/NoopRequest.java
@@ -38,7 +38,7 @@ public class NoopRequest extends BinaryRequest<Void> {
   @Override
   public ByteBuf writeRequest(final ByteBufAllocator alloc, final ByteBuffer dst) {
     dst.put(MAGIC_NUMBER);
-    dst.put(OpCode.NOOP);
+    dst.put(OpCode.NOOP.value());
     dst.putShort((short) 0); // byte 2-3
     dst.put((byte) 0); // byte 4
     dst.put((byte) 0);

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/ResponsePacket.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/ResponsePacket.java
@@ -17,9 +17,10 @@
 package com.spotify.folsom.client.binary;
 
 import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.client.OpCode;
 
 public class ResponsePacket {
-  public final byte opcode;
+  public final OpCode opcode;
   public final MemcacheStatus status;
   public final int opaque;
   public final long cas;
@@ -27,7 +28,7 @@ public class ResponsePacket {
   public final byte[] value;
 
   public ResponsePacket(
-      final byte opcode,
+      final OpCode opcode,
       final MemcacheStatus status,
       final int opaque,
       final long cas,

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/SetRequest.java
@@ -28,13 +28,13 @@ import java.nio.ByteBuffer;
 public class SetRequest extends BinaryRequest<MemcacheStatus>
     implements com.spotify.folsom.client.SetRequest {
 
-  private final byte opcode;
+  private final OpCode opcode;
   private final byte[] value;
   private final int ttl;
   private final long cas;
 
   public SetRequest(
-      final byte opcode, final byte[] key, final byte[] value, final int ttl, final long cas) {
+      final OpCode opcode, final byte[] key, final byte[] value, final int ttl, final long cas) {
     super(key);
     this.opcode = opcode;
     this.value = value;

--- a/folsom/src/test/java/com/spotify/folsom/client/OpCodeTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/OpCodeTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 public class OpCodeTest {
 
   @Test
-  public void testGetKind() throws Exception {
+  public void testGetKind() {
     assertEquals(OpCode.SET, OpCode.getKind(OpCode.SET));
     assertEquals(OpCode.SET, OpCode.getKind(OpCode.APPEND));
     assertEquals(OpCode.SET, OpCode.getKind(OpCode.REPLACE));
@@ -33,5 +33,27 @@ public class OpCodeTest {
     assertEquals(OpCode.GET, OpCode.getKind(OpCode.GETQ));
 
     assertEquals(OpCode.TOUCH, OpCode.getKind(OpCode.TOUCH));
+  }
+
+  @Test
+  public void testOf() {
+    assertEquals(OpCode.GET, OpCode.of(OpCode.GET.value()));
+    assertEquals(OpCode.SET, OpCode.of(OpCode.SET.value()));
+    assertEquals(OpCode.TAP_CHECKPOINT_END, OpCode.of(OpCode.TAP_CHECKPOINT_END.value()));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOfWithNegative() {
+    OpCode.of((byte) -1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOfWithOverflow() {
+    OpCode.of((byte) 0x48);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testOfWithUnknown() {
+    OpCode.of((byte) 0x23);
   }
 }

--- a/folsom/src/test/java/com/spotify/folsom/client/binary/BinaryMemcacheDecoderTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/binary/BinaryMemcacheDecoderTest.java
@@ -47,7 +47,7 @@ public class BinaryMemcacheDecoderTest {
 
     ByteBuf cb = Unpooled.buffer(30);
     cb.writeByte(0x81);
-    cb.writeByte(OpCode.GET);
+    cb.writeByte(OpCode.GET.value());
     cb.writeShort(3);
     cb.writeByte(0);
     cb.writeZero(1);

--- a/folsom/src/test/java/com/spotify/folsom/client/binary/RequestTestTemplate.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/binary/RequestTestTemplate.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
+import com.spotify.folsom.client.OpCode;
 import com.spotify.folsom.transcoder.StringTranscoder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
@@ -40,14 +41,14 @@ public abstract class RequestTestTemplate {
 
   protected void assertHeader(
       final ByteBuf b,
-      final int opcode,
+      final OpCode opcode,
       final int keyLength,
       final int extrasLength,
       final int totalLength,
       final int opaque,
       final long cas) {
     assertByte(0x80, b.readByte());
-    assertByte(opcode, b.readByte());
+    assertByte(opcode.value(), b.readByte());
     assertShort(keyLength, b.readShort());
     assertShort(extrasLength, b.readByte());
     assertZeros(b, 3);


### PR DESCRIPTION
Move OpCode into an enum of byte values. This change is expected to be
backwards compatible, but would cause invalid responses to throw an
exception (for an unknown opcode).