### PR TITLE
Add utility function to check if an executor is direct or not

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -83,6 +83,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
   private final BatchFlusher flusher;
   private final HostAndPort address;
   private final Executor executor;
+  private final boolean isDirectExecutor;
   private final long timeoutMillis;
   private final Metrics metrics;
   private final int maxSetLength;
@@ -194,6 +195,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
       int maxSetLength) {
     this.address = address;
     this.executor = executor;
+    this.isDirectExecutor = executor == null || Utils.isDirectExecutor(executor);
     this.timeoutMillis = timeoutMillis;
     this.metrics = metrics;
     this.maxSetLength = maxSetLength;
@@ -247,7 +249,11 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
   }
 
   private <T> CompletionStage<T> onExecutor(CompletionStage<T> future) {
-    return Utils.onExecutor(future, executor);
+    if (isDirectExecutor) {
+      return future;
+    } else {
+      return Utils.onExecutor(future, executor);
+    }
   }
 
   /**

--- a/folsom/src/test/java/com/spotify/folsom/client/UtilsTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/UtilsTest.java
@@ -2,11 +2,14 @@ package com.spotify.folsom.client;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ForkJoinPool;
 import org.junit.Test;
 
 public class UtilsTest {
@@ -69,5 +72,25 @@ public class UtilsTest {
           future.completeExceptionally(new RuntimeException());
         });
     assertEquals("thread-B-0", future2.get());
+  }
+
+  @Test
+  public void testIsDirectExecutor() {
+    assertDirect(MoreExecutors.directExecutor(), true);
+    assertDirect(MoreExecutors.newDirectExecutorService(), true);
+
+    assertDirect(ForkJoinPool.commonPool(), false);
+    assertDirect(Executors.newFixedThreadPool(1), false);
+    assertDirect(Executors.newFixedThreadPool(10), false);
+    assertDirect(Executors.newSingleThreadExecutor(), false);
+    assertDirect(Executors.newCachedThreadPool(), false);
+    assertDirect(Executors.newWorkStealingPool(), false);
+    assertDirect(Executors.newWorkStealingPool(10), false);
+  }
+
+  private void assertDirect(Executor executor, boolean expected) {
+    for (int i = 0; i < 1000000; i++) {
+      assertEquals(expected, Utils.isDirectExecutor(executor));
+    }
   }
 }


### PR DESCRIPTION
Don't move futures to different executor if it's a direct executor