### PR TITLE
Refactor resolver to be pluggable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ secure: "H4tUL1Greyj588Kb1/FnRapFT/57KaApQYAZx2KRORkddYSzPq2tovI1S8AnqzCHpVtfjin
 language: java
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk8
   - openjdk11
 
 install:

--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -231,6 +231,7 @@ public class MemcacheClientBuilder<V> {
   }
 
   /** @deprecated Use {@link #withResolver(Resolver)} with {@link SrvResolver} instead. */
+  @Deprecated
   public MemcacheClientBuilder<V> withSRVRecord(final String srvRecord) {
     this.srvRecord = requireNonNull(srvRecord);
     updateResolver();
@@ -250,6 +251,7 @@ public class MemcacheClientBuilder<V> {
   }
 
   /** @deprecated Use {@link #withResolveRefreshPeriod(long)} */
+  @Deprecated
   public MemcacheClientBuilder<V> withSRVRefreshPeriod(final long periodMillis) {
     return withResolveRefreshPeriod(periodMillis);
   }
@@ -267,11 +269,13 @@ public class MemcacheClientBuilder<V> {
   }
 
   /** @deprecated Use {@link #withResolveShutdownDelay(long)} */
+  @Deprecated
   public MemcacheClientBuilder<V> withSRVShutdownDelay(final long shutdownDelay) {
     return withResolveShutdownDelay(shutdownDelay);
   }
 
   /** @deprecated Use {@link #withResolver(Resolver)} with {@link SrvResolver} instead */
+  @Deprecated
   public MemcacheClientBuilder<V> withSrvResolver(final DnsSrvResolver srvResolver) {
     this.srvResolver = requireNonNull(srvResolver, "srvResolver");
     updateResolver();

--- a/folsom/src/main/java/com/spotify/folsom/Resolver.java
+++ b/folsom/src/main/java/com/spotify/folsom/Resolver.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Objects;
+
+public interface Resolver {
+
+  class ResolveResult {
+    private final String host;
+    private final int port;
+    private final long ttl;
+
+    public ResolveResult(String host, int port, long ttl) {
+      this.host = requireNonNull(host);
+      checkArgument(port > 0, "port must be a positive integer");
+      this.port = port;
+      checkArgument(ttl > 0, "ttl must be a positive integer");
+      this.ttl = ttl;
+    }
+
+    public String getHost() {
+      return host;
+    }
+
+    public int getPort() {
+      return port;
+    }
+
+    public long getTtl() {
+      return ttl;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      final ResolveResult that = (ResolveResult) o;
+      return port == that.port && ttl == that.ttl && Objects.equals(host, that.host);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(host, port, ttl);
+    }
+
+    @Override
+    public String toString() {
+      return "ResolveResult{host='" + host + "', port=" + port + ", ttl=" + ttl + '}';
+    }
+  }
+
+  List<ResolveResult> resolve();
+}

--- a/folsom/src/main/java/com/spotify/folsom/SrvResolver.java
+++ b/folsom/src/main/java/com/spotify/folsom/SrvResolver.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom;
+
+import static java.util.Objects.requireNonNull;
+
+import com.spotify.dns.DnsSrvResolver;
+import com.spotify.dns.DnsSrvResolvers;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SrvResolver implements Resolver {
+
+  public static class Builder {
+    private final String srvRecord;
+    private DnsSrvResolver srvResolver;
+
+    private Builder(final String srvRecord) {
+      this.srvRecord = requireNonNull(srvRecord, "srvRecord");
+    }
+
+    /**
+     * Use a specific DNS resolver.
+     *
+     * @param srvResolver the resolver to use. Default is a caching resolver from {@link
+     *     com.spotify.dns.DnsSrvResolvers}
+     * @return itself
+     */
+    public Builder withSrvResolver(final DnsSrvResolver srvResolver) {
+      this.srvResolver = requireNonNull(srvResolver, "srvResolver");
+      return this;
+    }
+
+    public SrvResolver build() {
+      DnsSrvResolver srvResolver = this.srvResolver;
+      if (srvResolver == null) {
+        srvResolver =
+            DnsSrvResolvers.newBuilder().cachingLookups(true).retainingDataOnFailures(true).build();
+      }
+
+      return new SrvResolver(srvResolver, srvRecord);
+    }
+  }
+
+  public static Builder newBuilder(final String srvRecord) {
+    return new Builder(srvRecord);
+  }
+
+  private final DnsSrvResolver dnsSrvResolver;
+  private final String srvRecord;
+
+  private SrvResolver(final DnsSrvResolver dnsSrvResolver, final String srvRecord) {
+    this.dnsSrvResolver = dnsSrvResolver;
+    this.srvRecord = srvRecord;
+  }
+
+  @Override
+  public List<ResolveResult> resolve() {
+    return dnsSrvResolver
+        .resolve(srvRecord)
+        .stream()
+        .map(result -> new ResolveResult(result.host(), result.port(), result.ttl()))
+        .collect(Collectors.toList());
+  }
+}

--- a/folsom/src/main/java/com/spotify/folsom/SrvResolver.java
+++ b/folsom/src/main/java/com/spotify/folsom/SrvResolver.java
@@ -18,12 +18,23 @@ package com.spotify.folsom;
 
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.base.Suppliers;
 import com.spotify.dns.DnsSrvResolver;
 import com.spotify.dns.DnsSrvResolvers;
 import java.util.List;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class SrvResolver implements Resolver {
+
+  private static final Supplier<DnsSrvResolver> DEFAULT_DNS_RESOLVER =
+      Suppliers.memoize(
+              () ->
+                  DnsSrvResolvers.newBuilder()
+                      .cachingLookups(true)
+                      .retainingDataOnFailures(true)
+                      .build())
+          ::get;
 
   public static class Builder {
     private final String srvRecord;
@@ -48,8 +59,7 @@ public class SrvResolver implements Resolver {
     public SrvResolver build() {
       DnsSrvResolver srvResolver = this.srvResolver;
       if (srvResolver == null) {
-        srvResolver =
-            DnsSrvResolvers.newBuilder().cachingLookups(true).retainingDataOnFailures(true).build();
+        srvResolver = DEFAULT_DNS_RESOLVER.get();
       }
 
       return new SrvResolver(srvResolver, srvRecord);

--- a/folsom/src/test/java/com/spotify/folsom/ResolveKetamaIntegrationTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/ResolveKetamaIntegrationTest.java
@@ -32,7 +32,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-public class SrvKetamaIntegrationTest {
+public class ResolveKetamaIntegrationTest {
 
   private KetamaServers servers = KetamaServers.SIMPLE_INSTANCE.get();
 

--- a/folsom/src/test/java/com/spotify/folsom/SrvResolverTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/SrvResolverTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.folsom;
+
+import static com.google.common.collect.ImmutableList.of;
+import static com.spotify.dns.LookupResult.create;
+import static org.junit.Assert.assertEquals;
+
+import com.spotify.dns.DnsSrvResolver;
+import com.spotify.folsom.Resolver.ResolveResult;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SrvResolverTest {
+
+  public static final String SRV_RECORD = "srv.record";
+  @Mock private DnsSrvResolver dnsSrvResolver;
+
+  @Test
+  public void testResolve() {
+    Mockito.when(dnsSrvResolver.resolve(SRV_RECORD))
+        .thenReturn(of(create("host1", 1, 2, 3, 4), create("host2", 5, 6, 7, 8)));
+
+    final SrvResolver resolver =
+        SrvResolver.newBuilder(SRV_RECORD).withSrvResolver(dnsSrvResolver).build();
+
+    final List<ResolveResult> result = resolver.resolve();
+
+    assertEquals(of(new ResolveResult("host1", 1, 4), new ResolveResult("host2", 5, 8)), result);
+  }
+}


### PR DESCRIPTION
Refactors the SRV resolver support to allow for any type of dynamic
resolver, for example for AWS ElastiCache.

Existing SRV builder methods are kept to ensure backwards compatibility,
but are marked as deprecated.