### PR TITLE
Add resolver for AWS ElastiCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ To import it with maven, use this:
       <version>1.6.0</version>
     </dependency>
 
+    <!-- optional if you want to use AWS ElastiCache auto-discovery -->
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>folsom-elasticache</artifactId>
+      <version>1.6.0</version>
+    </dependency>
+
 If you want to use one of the metrics or tracing libraries, make sure you use the same version as
 the main artifact.
 
@@ -173,6 +180,22 @@ using MemcacheClientBuilder:
 
 ```
 builder.withTracer(OpenCensus.tracer());
+```
+
+#### Cluster auto-discovery
+
+Nodes in a memcache clusters can be auto-discovered. Folsom supports discovery through 
+DNS SRV records using the `com.spotify.folsom.SrvResolver` or AWS ElastiCache using the
+`com.spotify.folsom.elasticache.ElastiCacheResolver`.
+
+SrvResolver:
+```
+builder.withResolver(SrvResolver.newBuilder("foo._tcp.example.org").build());
+```
+
+ElastiCacheResolver:
+```
+builder.withResolver(ElastiCacheResolver.newBuilder("cluster-configuration-endpoint-hostname").build());
 ```
 
 ### Building

--- a/folsom-elasticache/pom.xml
+++ b/folsom-elasticache/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify</groupId>
+    <artifactId>folsom-parent</artifactId>
+    <version>1.6.3-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>folsom-elasticache</artifactId>
+
+  <developers>
+    <developer>
+      <name>Niklas Gustavsson</name>
+      <email>ngn@spotify.com</email>
+    </developer>
+  </developers>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>folsom</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/folsom-elasticache/src/main/java/com/spotify/folsom/elasticache/ElastiCacheResolver.java
+++ b/folsom-elasticache/src/main/java/com/spotify/folsom/elasticache/ElastiCacheResolver.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom.elasticache;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.stream.Collectors.toList;
+
+import com.spotify.folsom.Resolver;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.List;
+
+/**
+ * Implement support for AWS ElastiCache node auto-discovery <a
+ * href="https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/AutoDiscovery.AddingToYourClientLibrary.html">as
+ * documented</a>.
+ *
+ * <p>Example use:
+ *
+ * <pre>{@code
+ * ElastiCacheResolver resolver = ElastiCacheResolver
+ *          .newBuilder("cluster-configuration-endpoint-hostname")
+ *          .build();
+ *
+ *  MemcacheClientBuilder.newStringClient()
+ *          .withResolver(resolver)
+ *          ...
+ * }</pre>
+ */
+public class ElastiCacheResolver implements Resolver {
+
+  public static class Builder {
+    private final String configHost;
+    private int configPort = 11211;
+    private long ttl = MINUTES.toMillis(1);
+    private int timeout = 5000; // ms
+
+    private Builder(final String configHost) {
+      this.configHost = configHost;
+    }
+
+    /**
+     * Set the configuration endpoint port. Default: 11211.
+     *
+     * @param port The port
+     * @return The builder
+     */
+    public Builder withConfigPort(final int port) {
+      checkArgument(port > 0, "port must be an integer 1-65535");
+      checkArgument(port < 65536, "port must be an integer 1-65535");
+      this.configPort = port;
+      return this;
+    }
+
+    /**
+     * Set the time to live for a resolution result. That is, this controls how frequent the list of
+     * cluster nodes is renewed. Default: 600000 ms (1 min)
+     *
+     * @param ttl Time to live in milliseconds
+     * @return The builder
+     */
+    public Builder withTtlMillis(final long ttl) {
+      checkArgument(ttl > 0, "ttl must be a positive integer");
+      this.ttl = ttl;
+      return this;
+    }
+
+    /**
+     * Set the socket timeout for a resolution attempt. Default: 5000 ms
+     *
+     * @param timeout The timeout in milliseconds
+     * @return The builder
+     */
+    public Builder withResolveTimeoutMillis(final int timeout) {
+      checkArgument(timeout > 0, "timeout must be a positive integer");
+      this.timeout = timeout;
+      return this;
+    }
+
+    /**
+     * Build the resolver
+     *
+     * @return The resolver
+     */
+    public ElastiCacheResolver build() {
+      return new ElastiCacheResolver(configHost, configPort, ttl, timeout);
+    }
+  }
+
+  private static final byte[] CMD = "config get cluster\n".getBytes(US_ASCII);
+
+  /**
+   * Build a new resolver.
+   *
+   * @param configHost The configuration endpoint hostname, e.g
+   *     foo.o18xjv.cfg.euw1.cache.amazonaws.com
+   * @return The builder
+   */
+  public static Builder newBuilder(final String configHost) {
+    return new Builder(configHost);
+  }
+
+  private final String configHost;
+  private final int configPort;
+  private final long ttl;
+  private final int timeout;
+  private final ResponseParser parser;
+
+  private ElastiCacheResolver(
+      final String configHost, final int configPort, final long ttl, final int timeout) {
+    this.configHost = configHost;
+    this.configPort = configPort;
+    this.ttl = ttl;
+    this.parser = new ResponseParser();
+    this.timeout = timeout;
+  }
+
+  @Override
+  public List<ResolveResult> resolve() {
+    try (final Socket socket = new Socket()) {
+      socket.setSoTimeout(timeout);
+      socket.connect(new InetSocketAddress(configHost, configPort), timeout);
+
+      socket.getOutputStream().write(CMD);
+
+      return parser
+          .parse(socket.getInputStream())
+          .stream()
+          .map(hap -> new ResolveResult(hap.getHostText(), hap.getPort(), ttl))
+          .collect(toList());
+    } catch (IOException e) {
+      throw new RuntimeException("ElastiCache auto-discovery failed", e);
+    }
+  }
+}

--- a/folsom-elasticache/src/main/java/com/spotify/folsom/elasticache/ResponseParser.java
+++ b/folsom-elasticache/src/main/java/com/spotify/folsom/elasticache/ResponseParser.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom.elasticache;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+import com.google.common.base.Splitter;
+import com.spotify.folsom.guava.HostAndPort;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ResponseParser {
+
+  public List<HostAndPort> parse(final InputStream in) throws IOException {
+    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(in, US_ASCII))) {
+      final String response = reader.readLine().trim();
+
+      if (response.startsWith("CONFIG cluster ")) {
+        reader.readLine(); // configuration version, not used
+
+        final List<String> hosts = Splitter.on(' ').splitToList(reader.readLine());
+
+        final List<HostAndPort> result = new ArrayList<>();
+        for (final String host : hosts) {
+          final List<String> tokens = Splitter.on('|').splitToList(host);
+          if (tokens.size() != 3) {
+            throw new IOException("Expected 3 parts for a host, but got " + host);
+          }
+
+          // the private IP is not guaranteed to be included, so use the CNAME
+          result.add(HostAndPort.fromParts(tokens.get(0), Integer.valueOf(tokens.get(2))));
+        }
+
+        // validate complete response
+        final String emptyLine = reader.readLine();
+        if (!"".equals(emptyLine)) {
+          throw new IOException("Expected empty trailing line, invalid server response");
+        }
+        final String end = reader.readLine();
+        if (!"END".equals(end)) {
+          throw new IOException("Expected end of response, invalid server response");
+        }
+
+        return result;
+      } else {
+        throw new IOException("Unexpected server response: " + response);
+      }
+    }
+  }
+}

--- a/folsom-elasticache/src/test/java/com/spotify/folsom/elasticache/ResponseParserTest.java
+++ b/folsom-elasticache/src/test/java/com/spotify/folsom/elasticache/ResponseParserTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom.elasticache;
+
+import static com.spotify.folsom.guava.HostAndPort.fromParts;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.Test;
+
+public class ResponseParserTest {
+
+  private final ResponseParser parser = new ResponseParser();
+
+  @Test
+  public void parseFull() throws IOException {
+    final InputStream in =
+        in("CONFIG cluster 0 140\n2\nhost1|172.31.15.57|11211 host2|172.31.8.107|11212\n\r\nEND");
+
+    assertEquals(asList(fromParts("host1", 11211), fromParts("host2", 11212)), parser.parse(in));
+  }
+
+  @Test
+  public void parseSingleNode() throws IOException {
+    final InputStream in = in("CONFIG cluster 0 140\n2\nhost1|172.31.15.57|11211\n\r\nEND");
+
+    assertEquals(asList(fromParts("host1", 11211)), parser.parse(in));
+  }
+
+  @Test
+  public void parseNoIp() throws IOException {
+    final InputStream in =
+        in("CONFIG cluster 0 140\n2\nhost1||11211 host2|172.31.8.107|11212\n\r\nEND");
+
+    assertEquals(asList(fromParts("host1", 11211), fromParts("host2", 11212)), parser.parse(in));
+  }
+
+  @Test(expected = IOException.class)
+  public void parseMissingEnd() throws IOException {
+    final InputStream in = in("CONFIG cluster 0 140\n2\nhost1|172.31.15.57|11211\n\r\n");
+
+    parser.parse(in);
+  }
+
+  @Test(expected = IOException.class)
+  public void parseMissingEmpty() throws IOException {
+    final InputStream in = in("CONFIG cluster 0 140\n2\nhost1|172.31.15.57|11211\n");
+
+    parser.parse(in);
+  }
+
+  @Test(expected = IOException.class)
+  public void parseError() throws IOException {
+    final InputStream in = in("END");
+
+    parser.parse(in);
+  }
+
+  private ByteArrayInputStream in(final String response) {
+    return new ByteArrayInputStream(response.getBytes(US_ASCII));
+  }
+}

--- a/folsom-opencensus/pom.xml
+++ b/folsom-opencensus/pom.xml
@@ -43,6 +43,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
       <version>${opencensus.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <module>folsom-semantic-metrics</module>
     <module>folsom-yammer-metrics</module>
     <module>folsom-opencensus</module>
+    <module>folsom-elasticache</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
Add an implementation of the AWS ElastiCache node auto-discovery
protocol, allowing Folsom to dynamically resolve ElastiCache clusters.