### PR TITLE
Take ElastiCache configuration version into account

### DIFF
--- a/folsom-elasticache/src/main/java/com/spotify/folsom/elasticache/Response.java
+++ b/folsom-elasticache/src/main/java/com/spotify/folsom/elasticache/Response.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom.elasticache;
+
+import com.spotify.folsom.guava.HostAndPort;
+import java.util.List;
+
+public class Response {
+
+  private final int configurationVersion;
+  private final List<HostAndPort> hosts;
+
+  public Response(final int configurationVersion, final List<HostAndPort> result) {
+    this.configurationVersion = configurationVersion;
+    this.hosts = result;
+  }
+
+  public int getConfigurationVersion() {
+    return configurationVersion;
+  }
+
+  public List<HostAndPort> getHosts() {
+    return hosts;
+  }
+}

--- a/folsom-elasticache/src/main/java/com/spotify/folsom/elasticache/ResponseParser.java
+++ b/folsom-elasticache/src/main/java/com/spotify/folsom/elasticache/ResponseParser.java
@@ -29,12 +29,12 @@ import java.util.List;
 
 public class ResponseParser {
 
-  public List<HostAndPort> parse(final InputStream in) throws IOException {
+  public Response parse(final InputStream in) throws IOException {
     try (final BufferedReader reader = new BufferedReader(new InputStreamReader(in, US_ASCII))) {
       final String response = reader.readLine().trim();
 
       if (response.startsWith("CONFIG cluster ")) {
-        reader.readLine(); // configuration version, not used
+        final int configVersion = Integer.valueOf(reader.readLine()); // configuration version
 
         final List<String> hosts = Splitter.on(' ').splitToList(reader.readLine());
 
@@ -59,7 +59,7 @@ public class ResponseParser {
           throw new IOException("Expected end of response, invalid server response");
         }
 
-        return result;
+        return new Response(configVersion, result);
       } else {
         throw new IOException("Unexpected server response: " + response);
       }

--- a/folsom-elasticache/src/test/java/com/spotify/folsom/elasticache/ElastiCacheResolverTest.java
+++ b/folsom-elasticache/src/test/java/com/spotify/folsom/elasticache/ElastiCacheResolverTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014-2019 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom.elasticache;
+
+import static com.google.common.collect.Iterators.cycle;
+import static com.spotify.folsom.guava.HostAndPort.fromParts;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+import com.spotify.folsom.Resolver.ResolveResult;
+import java.util.Iterator;
+import org.junit.Test;
+
+public class ElastiCacheResolverTest {
+
+  @Test
+  public void resolve() {
+    final Response response =
+        new Response(123, asList(fromParts("host1", 11211), fromParts("host2", 11212)));
+
+    final ElastiCacheResolver resolver = new ElastiCacheResolver(() -> response, 124);
+
+    assertEquals(
+        asList(new ResolveResult("host1", 11211, 124), new ResolveResult("host2", 11212, 124)),
+        resolver.resolve());
+  }
+
+  @Test
+  public void resolveNewerVersions() {
+    final Response response1 = new Response(123, singletonList(fromParts("host1", 11211)));
+    final Response response2 = new Response(124, singletonList(fromParts("host2", 11211)));
+    final Iterator<Response> responses = cycle(response1, response2);
+
+    final ElastiCacheResolver resolver = new ElastiCacheResolver(() -> responses.next(), 124);
+
+    // version 123 response, no cached result so return resolve result
+    assertEquals(singletonList(new ResolveResult("host1", 11211, 124)), resolver.resolve());
+
+    // version 124 response, newer than cached result
+    assertEquals(singletonList(new ResolveResult("host2", 11211, 124)), resolver.resolve());
+
+    // version 123 response, return cached result
+    assertEquals(singletonList(new ResolveResult("host2", 11211, 124)), resolver.resolve());
+  }
+}

--- a/folsom-elasticache/src/test/java/com/spotify/folsom/elasticache/ResponseParserTest.java
+++ b/folsom-elasticache/src/test/java/com/spotify/folsom/elasticache/ResponseParserTest.java
@@ -35,14 +35,18 @@ public class ResponseParserTest {
     final InputStream in =
         in("CONFIG cluster 0 140\n2\nhost1|172.31.15.57|11211 host2|172.31.8.107|11212\n\r\nEND");
 
-    assertEquals(asList(fromParts("host1", 11211), fromParts("host2", 11212)), parser.parse(in));
+    final Response response = parser.parse(in);
+    assertEquals(2, response.getConfigurationVersion());
+    assertEquals(asList(fromParts("host1", 11211), fromParts("host2", 11212)), response.getHosts());
   }
 
   @Test
   public void parseSingleNode() throws IOException {
     final InputStream in = in("CONFIG cluster 0 140\n2\nhost1|172.31.15.57|11211\n\r\nEND");
 
-    assertEquals(asList(fromParts("host1", 11211)), parser.parse(in));
+    final Response response = parser.parse(in);
+    assertEquals(2, response.getConfigurationVersion());
+    assertEquals(asList(fromParts("host1", 11211)), response.getHosts());
   }
 
   @Test
@@ -50,7 +54,9 @@ public class ResponseParserTest {
     final InputStream in =
         in("CONFIG cluster 0 140\n2\nhost1||11211 host2|172.31.8.107|11212\n\r\nEND");
 
-    assertEquals(asList(fromParts("host1", 11211), fromParts("host2", 11212)), parser.parse(in));
+    final Response response = parser.parse(in);
+    assertEquals(2, response.getConfigurationVersion());
+    assertEquals(asList(fromParts("host1", 11211), fromParts("host2", 11212)), response.getHosts());
   }
 
   @Test(expected = IOException.class)


### PR DESCRIPTION
For the ElastiCache node discovery protocol, make sure we take the
configuration version into account. This will make sure we do not
accidentally use an old configuration version in an eventually
consistent system.