### PR TITLE
deprecate withRequestBatchSize

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.spotify.folsom.client.MemcacheEncoder.MAX_KEY_LEN;
 import static java.util.Objects.requireNonNull;
 
-import com.google.common.annotations.Beta;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -327,37 +326,34 @@ public class MemcacheClientBuilder<V> {
    *
    * <p>Note: The name of this configuration property is misleading.
    *
-   * <p>Configuring this is only useful in specific circumstances when also using
-   * {@link #withEventLoopGroup(EventLoopGroup)} to configure an IO thread pool that is also used
-   * to send requests. E.g. when reusing the same {@link EventLoopGroup} for handling incoming
-   * network IO and sending memcache requests in a service.
+   * <p>Configuring this is only useful in specific circumstances when also using {@link
+   * #withEventLoopGroup(EventLoopGroup)} to configure an IO thread pool that is also used to send
+   * requests. E.g. when reusing the same {@link EventLoopGroup} for handling incoming network IO
+   * and sending memcache requests in a service.
    *
    * @see #withEventLoopThreadFlushMaxBatchSize(int)
    * @param eventLoopThreadFlushMaxBatchSize the maximum number of requests that will be written to
-   *                                         a connection in a single operation when sending
-   *                                         requests on the {@link EventLoopGroup} thread that is
-   *                                         handling the connection. Default is
-   *                                         {@value Settings#DEFAULT_BATCH_SIZE}.
+   *     a connection in a single operation when sending requests on the {@link EventLoopGroup}
+   *     thread that is handling the connection. Default is {@value Settings#DEFAULT_BATCH_SIZE}.
    * @return itself
    * @deprecated Most users should prefer {@link #withMaxOutstandingRequests(int)}. Some users that
-   *     also configure {@link #withEventLoopGroup(EventLoopGroup)} might want to configure
-   *     {@link #withEventLoopThreadFlushMaxBatchSize(int)}.
+   *     also configure {@link #withEventLoopGroup(EventLoopGroup)} might want to configure {@link
+   *     #withEventLoopThreadFlushMaxBatchSize(int)}.
    */
   @Deprecated
   public MemcacheClientBuilder<V> withRequestBatchSize(final int eventLoopThreadFlushMaxBatchSize) {
     return withEventLoopThreadFlushMaxBatchSize(eventLoopThreadFlushMaxBatchSize);
   }
 
-
   /**
    * Specify the maximum number of requests that will be written to a connection in a single
    * operation when sending requests on the {@link EventLoopGroup} thread that is handling the
    * connection.
    *
-   * <p>Configuring this can be useful in specific circumstances when also using
-   * {@link #withEventLoopGroup(EventLoopGroup)} to configure an IO thread pool that is also used
-   * to send requests. E.g. when reusing the same {@link EventLoopGroup} for handling incoming
-   * network IO and sending memcache requests in a service.
+   * <p>Configuring this can be useful in specific circumstances when also using {@link
+   * #withEventLoopGroup(EventLoopGroup)} to configure an IO thread pool that is also used to send
+   * requests. E.g. when reusing the same {@link EventLoopGroup} for handling incoming network IO
+   * and sending memcache requests in a service.
    *
    * <p>If the client's batch-size is larger than your memcached server's value, you may experience
    * an increase in `conn_yields` on your memcached server's stats...which indicates your server is
@@ -370,13 +366,12 @@ public class MemcacheClientBuilder<V> {
    * memcached server's `-R` argument, which defaults to 20.
    *
    * @param eventLoopThreadFlushMaxBatchSize the maximum number of requests that will be written to
-   *                                         a connection in a single operation when sending requests
-   *                                         on the {@link EventLoopGroup} thread that is handling the
-   *                                         connection. Default is
-   *                                         {@value Settings#DEFAULT_BATCH_SIZE}.
+   *     a connection in a single operation when sending requests on the {@link EventLoopGroup}
+   *     thread that is handling the connection. Default is {@value Settings#DEFAULT_BATCH_SIZE}.
    * @return itself
    */
-  public MemcacheClientBuilder<V> withEventLoopThreadFlushMaxBatchSize(final int eventLoopThreadFlushMaxBatchSize) {
+  public MemcacheClientBuilder<V> withEventLoopThreadFlushMaxBatchSize(
+      final int eventLoopThreadFlushMaxBatchSize) {
     checkArgument(eventLoopThreadFlushMaxBatchSize > 0, "batch size must be > 0");
     this.eventLoopThreadFlushMaxBatchSize = eventLoopThreadFlushMaxBatchSize;
     return this;

--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.spotify.folsom.client.MemcacheEncoder.MAX_KEY_LEN;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -91,7 +92,7 @@ public class MemcacheClientBuilder<V> {
 
   private final List<HostAndPort> addresses = new ArrayList<>();
   private int maxOutstandingRequests = DEFAULT_MAX_OUTSTANDING;
-  private int batchSize = Settings.DEFAULT_BATCH_SIZE;
+  private int eventLoopThreadFlushMaxBatchSize = Settings.DEFAULT_BATCH_SIZE;
   private final Transcoder<V> valueTranscoder;
   private Metrics metrics = NoopMetrics.INSTANCE;
   private Tracer tracer = NoopTracer.INSTANCE;
@@ -320,7 +321,43 @@ public class MemcacheClientBuilder<V> {
   }
 
   /**
-   * Specify the maximum number of operations that will be batched together in one network request.
+   * Specify the maximum number of requests that will be written to a connection in a single
+   * operation when sending requests on the {@link EventLoopGroup} thread that is handling the
+   * connection.
+   *
+   * <p>Note: The name of this configuration property is misleading.
+   *
+   * <p>Configuring this is only useful in specific circumstances when also using
+   * {@link #withEventLoopGroup(EventLoopGroup)} to configure an IO thread pool that is also used
+   * to send requests. E.g. when reusing the same {@link EventLoopGroup} for handling incoming
+   * network IO and sending memcache requests in a service.
+   *
+   * @see #withEventLoopThreadFlushMaxBatchSize(int)
+   * @param eventLoopThreadFlushMaxBatchSize the maximum number of requests that will be written to
+   *                                         a connection in a single operation when sending
+   *                                         requests on the {@link EventLoopGroup} thread that is
+   *                                         handling the connection. Default is
+   *                                         {@value Settings#DEFAULT_BATCH_SIZE}.
+   * @return itself
+   * @deprecated Most users should prefer {@link #withMaxOutstandingRequests(int)}. Some users that
+   *     also configure {@link #withEventLoopGroup(EventLoopGroup)} might want to configure
+   *     {@link #withEventLoopThreadFlushMaxBatchSize(int)}.
+   */
+  @Deprecated
+  public MemcacheClientBuilder<V> withRequestBatchSize(final int eventLoopThreadFlushMaxBatchSize) {
+    return withEventLoopThreadFlushMaxBatchSize(eventLoopThreadFlushMaxBatchSize);
+  }
+
+
+  /**
+   * Specify the maximum number of requests that will be written to a connection in a single
+   * operation when sending requests on the {@link EventLoopGroup} thread that is handling the
+   * connection.
+   *
+   * <p>Configuring this can be useful in specific circumstances when also using
+   * {@link #withEventLoopGroup(EventLoopGroup)} to configure an IO thread pool that is also used
+   * to send requests. E.g. when reusing the same {@link EventLoopGroup} for handling incoming
+   * network IO and sending memcache requests in a service.
    *
    * <p>If the client's batch-size is larger than your memcached server's value, you may experience
    * an increase in `conn_yields` on your memcached server's stats...which indicates your server is
@@ -332,13 +369,16 @@ public class MemcacheClientBuilder<V> {
    * <p>The optimal value should be matched to your workload and roughly the same value as your
    * memcached server's `-R` argument, which defaults to 20.
    *
-   * @param batchSize the maximum number of operations per batched client request. Default is
-   *     {@value Settings#DEFAULT_BATCH_SIZE}.
+   * @param eventLoopThreadFlushMaxBatchSize the maximum number of requests that will be written to
+   *                                         a connection in a single operation when sending requests
+   *                                         on the {@link EventLoopGroup} thread that is handling the
+   *                                         connection. Default is
+   *                                         {@value Settings#DEFAULT_BATCH_SIZE}.
    * @return itself
    */
-  public MemcacheClientBuilder<V> withRequestBatchSize(final int batchSize) {
-    checkArgument(batchSize > 0, "batch size must be > 0");
-    this.batchSize = batchSize;
+  public MemcacheClientBuilder<V> withEventLoopThreadFlushMaxBatchSize(final int eventLoopThreadFlushMaxBatchSize) {
+    checkArgument(eventLoopThreadFlushMaxBatchSize > 0, "batch size must be > 0");
+    this.eventLoopThreadFlushMaxBatchSize = eventLoopThreadFlushMaxBatchSize;
     return this;
   }
 
@@ -645,7 +685,7 @@ public class MemcacheClientBuilder<V> {
         ReconnectingClient.singletonExecutor(),
         address,
         maxOutstandingRequests,
-        batchSize,
+        eventLoopThreadFlushMaxBatchSize,
         binary,
         authenticator,
         executor.get(),

--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -104,7 +104,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
   public static CompletionStage<RawMemcacheClient> connect(
       final HostAndPort address,
       final int outstandingRequestLimit,
-      final int batchSize,
+      final int eventLoopThreadFlushMaxBatchSize,
       final boolean binary,
       final Executor executor,
       final long connectionTimeoutMillis,
@@ -167,7 +167,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
                         address,
                         channel,
                         outstandingRequestLimit,
-                        batchSize,
+                        eventLoopThreadFlushMaxBatchSize,
                         executor,
                         connectionTimeoutMillis,
                         metrics,
@@ -190,7 +190,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
       final HostAndPort address,
       final Channel channel,
       final int outstandingRequestLimit,
-      final int batchSize,
+      final int eventLoopThreadFlushMaxBatchSize,
       final Executor executor,
       final long connectionTimeoutMillis,
       final Metrics metrics,
@@ -201,7 +201,7 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
     this.metrics = metrics;
     this.maxSetLength = maxSetLength;
     this.channel = requireNonNull(channel, "channel");
-    this.flusher = new BatchFlusher(channel, batchSize);
+    this.flusher = new BatchFlusher(channel, eventLoopThreadFlushMaxBatchSize);
     this.outstandingRequestLimit = outstandingRequestLimit;
 
     // Since we are reusing the pendingCounter to detect disconnects, set the limit to something

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -65,7 +65,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
       final ScheduledExecutorService scheduledExecutorService,
       final HostAndPort address,
       final int outstandingRequestLimit,
-      final int batchSize,
+      final int eventLoopThreadFlushMaxBatchSize,
       final boolean binary,
       final Authenticator authenticator,
       final Executor executor,
@@ -82,7 +82,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
             DefaultRawMemcacheClient.connect(
                 address,
                 outstandingRequestLimit,
-                batchSize,
+                eventLoopThreadFlushMaxBatchSize,
                 binary,
                 executor,
                 connectionTimeoutMillis,


### PR DESCRIPTION
The `withRequestBatchSize` configuration property documentation is currently incorrect and misleading.

* Deprecate `withRequestBatchSize`.
* Introduce `withEventLoopThreadFlushMaxBatchSize` to cover the special
  use case served by `withRequestBatchSize`.