### PR TITLE
Fixed versions for CI/CD and JDK distro to support it

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v2
       with:
-        distribution: 'temurin'
+        distribution: 'zulu'
         java-version: ${{ matrix.java }}
 
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        java: [ '8', '11', '15' ]
+        java: ['8', '8.0.192', '11', '11.0.3', '15', '15.0.1' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up JDK 1.8
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
 
     - name: Build with Maven


### PR DESCRIPTION
Adopt is no more, projects need to switch away from Adopt, to one of the alternatives, either Temurin or Zulu, Temurin is available, though doesn't support all the JDK versions, while Zulu does: https://github.com/geertjanw/folsom/actions

Testing against fixed versions as well as the latest version will enable projects to easily see that a failure is due to the latest version (if it is red) if the fixed version succeeds (when it is green), and not a result of build failures arising from your application code.