### PR TITLE
Add Micrometer metrics option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ to wait for the initial connection to succeed, as can be seen in the example bel
 final MemcacheClient<String> client = MemcacheClientBuilder.newStringClient()
     .withAddress(hostname)
     .connectAscii();
-// make we wait until the client has connected to the server
+// make it wait until the client has connected to the server
 ConnectFuture.connectFuture(client).toCompletableFuture().get();
 
 client.set("key", "value", 10000).toCompletableFuture().get();
@@ -185,6 +185,17 @@ Folsom support Ketama for sharing across a set of memcache servers. Note that
 the caching algorithm (currently) doesn't attempt to provide compatibility with
 other memcache clients, and thus when switching client implementation you will
 get a period of low cache hit ratio.
+
+#### Micrometer metrics
+
+You can optionally choose to track performance using
+[Micrometer metrics](https://micrometer.io/).
+You will need to include the `folsom-micrometer-metrics` dependency and initialize
+using MemcacheClientBuilder. (Optionally add additional tags):
+
+```
+builder.withMetrics(new MicrometerMetrics(metricsRegistry));
+```
 
 #### Yammer metrics
 

--- a/folsom-micrometer-metrics/pom.xml
+++ b/folsom-micrometer-metrics/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.spotify</groupId>
+    <artifactId>folsom-parent</artifactId>
+    <version>1.9.5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>folsom-micrometer-metrics</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.spotify</groupId>
+      <artifactId>folsom</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.7.4</version>
+    </dependency>
+
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/folsom-micrometer-metrics/src/main/java/com/spotify/folsom/client/MicrometerMetrics.java
+++ b/folsom-micrometer-metrics/src/main/java/com/spotify/folsom/client/MicrometerMetrics.java
@@ -70,7 +70,7 @@ public class MicrometerMetrics implements Metrics {
      * @param registry MeterRegistry
      * @param tags Additional tags that will be added to each meter
      */
-    public MicrometerMetrics(final MeterRegistry registry, String... tags) {
+    public MicrometerMetrics(final MeterRegistry registry, final String... tags) {
         this(registry, Tags.of(tags));
     }
 
@@ -79,7 +79,7 @@ public class MicrometerMetrics implements Metrics {
      * @param registry MeterRegistry
      * @param tags Additional tags that will be added to each meter
      */
-    public MicrometerMetrics(final MeterRegistry registry, Tags tags) {
+    public MicrometerMetrics(final MeterRegistry registry, final Tags tags) {
         String meterName = "memcache.requests";
         this.getHits = registry.timer(meterName, tags.and("operation", "get", "result", "hits"));
         this.getMisses = registry.timer(meterName, tags.and("operation", "get", "result", "misses"));

--- a/folsom-micrometer-metrics/src/main/java/com/spotify/folsom/client/MicrometerMetrics.java
+++ b/folsom-micrometer-metrics/src/main/java/com/spotify/folsom/client/MicrometerMetrics.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2014-2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.spotify.folsom.GetResult;
+import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.Metrics;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class MicrometerMetrics implements Metrics {
+
+    private final Timer getHits;
+    private final Timer getMisses;
+    private final Timer getFailures;
+
+    private final Timer multigetCalls;
+    private final Counter multigetHits;
+    private final Counter multigetMisses;
+    private final Timer multigetFailures;
+
+    private final Timer setSuccesses;
+    private final Timer setFailures;
+
+    private final Timer deleteSuccesses;
+    private final Timer deleteFailures;
+
+    private final Timer incrDecrSuccesses;
+    private final Timer incrDecrFailures;
+
+    private final Timer touchSuccesses;
+    private final Timer touchFailures;
+
+    private final Set<OutstandingRequestsGauge> gauges = new CopyOnWriteArraySet<>();
+
+    /**
+     *
+     * @param registry MeterRegistry
+     */
+    public MicrometerMetrics(final MeterRegistry registry) {
+        this(registry, Tags.empty());
+    }
+
+    /**
+     *
+     * @param registry MeterRegistry
+     * @param tags Additional tags that will be added to each meter
+     */
+    public MicrometerMetrics(final MeterRegistry registry, String... tags) {
+        this(registry, Tags.of(tags));
+    }
+
+    /**
+     *
+     * @param registry MeterRegistry
+     * @param tags Additional tags that will be added to each meter
+     */
+    public MicrometerMetrics(final MeterRegistry registry, Tags tags) {
+        String meterName = "memcache.requests";
+        this.getHits = registry.timer(meterName, tags.and("operation", "get", "result", "hits"));
+        this.getMisses = registry.timer(meterName, tags.and("operation", "get", "result", "misses"));
+        this.getFailures = registry.timer(meterName, tags.and("operation", "get", "result", "failures"));
+
+        this.multigetCalls = registry.timer(meterName, tags.and("operation", "multiget", "result", "hitsOrMisses"));
+        this.multigetHits = registry.counter(meterName, tags.and("operation", "multiget", "result", "hits"));
+        this.multigetMisses = registry.counter(meterName, tags.and("operation", "multiget", "result", "misses"));
+        this.multigetFailures = registry.timer(meterName, tags.and("operation", "multiget", "result", "failures"));
+
+        this.setSuccesses = registry.timer(meterName, tags.and("operation", "set", "result", "successes"));
+        this.setFailures = registry.timer(meterName, tags.and("operation", "set", "result", "failures"));
+
+        this.deleteSuccesses = registry.timer(meterName, tags.and("operation", "delete", "result", "successes"));
+        this.deleteFailures = registry.timer(meterName, tags.and("operation", "delete", "result", "failures"));
+
+        this.incrDecrSuccesses = registry.timer(meterName, tags.and("operation", "incrdecr", "result", "successes"));
+        this.incrDecrFailures = registry.timer(meterName, tags.and("operation", "incrdecr", "result", "failures"));
+
+        this.touchSuccesses = registry.timer(meterName, tags.and("operation", "touch", "result", "successes"));
+        this.touchFailures = registry.timer(meterName, tags.and("operation", "touch", "result", "failures"));
+
+        registry.gauge("memcache.outstandingRequests", tags, this, MicrometerMetrics::getOutstandingRequests);
+        registry.gauge("memcache.global.connections", tags, this, o -> Utils.getGlobalConnectionCount());
+    }
+
+    @VisibleForTesting
+    long getOutstandingRequests() {
+        return gauges.stream().mapToLong(OutstandingRequestsGauge::getOutstandingRequests).sum();
+    }
+
+    @Override
+    public void measureGetFuture(CompletionStage<GetResult<byte[]>> future) {
+        final long startNs = System.nanoTime();
+
+        future.whenComplete(
+                (result, t) -> {
+                    long duration = System.nanoTime() - startNs;
+                    if (t == null) {
+                        if (result != null) {
+                            getHits.record(duration, NANOSECONDS);
+                        } else {
+                            getMisses.record(duration, NANOSECONDS);
+                        }
+                    } else {
+                        getFailures.record(duration, NANOSECONDS);
+                    }
+                });
+    }
+
+    @Override
+    public void measureMultigetFuture(CompletionStage<List<GetResult<byte[]>>> future) {
+        final long startNs = System.nanoTime();
+
+        future.whenComplete(
+                (result, t) -> {
+                    long duration = System.nanoTime() - startNs;
+                    if (t == null) {
+                        multigetCalls.record(duration, NANOSECONDS);
+
+                        int hits = 0;
+                        int total = result.size();
+                        for (GetResult<byte[]> getResult : result) {
+                            if (getResult != null) {
+                                hits++;
+                            }
+                        }
+
+                        multigetHits.increment(hits);
+                        multigetMisses.increment(total - hits);
+                    } else {
+                        multigetFailures.record(duration, NANOSECONDS);;
+                    }
+                });
+    }
+
+    @Override
+    public void measureDeleteFuture(CompletionStage<MemcacheStatus> future) {
+        final long startNs = System.nanoTime();
+
+        future.whenComplete(
+                (result, t) -> {
+                    long duration = System.nanoTime() - startNs;
+                    if (t == null) {
+                        deleteSuccesses.record(duration, NANOSECONDS);
+                    } else {
+                        deleteFailures.record(duration, NANOSECONDS);
+                    }
+                });
+    }
+
+    @Override
+    public void measureSetFuture(CompletionStage<MemcacheStatus> future) {
+        final long startNs = System.nanoTime();
+
+        future.whenComplete(
+                (result, t) -> {
+                    long duration = System.nanoTime() - startNs;
+                    if (t == null) {
+                        setSuccesses.record(duration, NANOSECONDS);
+                    } else {
+                        setFailures.record(duration, NANOSECONDS);
+                    }
+                });
+    }
+
+    @Override
+    public void measureIncrDecrFuture(CompletionStage<Long> future) {
+        final long startNs = System.nanoTime();
+
+        future.whenComplete(
+                (result, t) -> {
+                    long duration = System.nanoTime() - startNs;
+                    if (t == null) {
+                        incrDecrSuccesses.record(duration, NANOSECONDS);
+                    } else {
+                        incrDecrFailures.record(duration, NANOSECONDS);
+                    }
+                });
+    }
+
+    @Override
+    public void measureTouchFuture(CompletionStage<MemcacheStatus> future) {
+        final long startNs = System.nanoTime();
+
+        future.whenComplete(
+                (result, t) -> {
+                    long duration = System.nanoTime() - startNs;
+                    if (t == null) {
+                        touchSuccesses.record(duration, NANOSECONDS);
+                    } else {
+                        touchFailures.record(duration, NANOSECONDS);
+                    }
+                });
+    }
+
+    @Override
+    public void registerOutstandingRequestsGauge(OutstandingRequestsGauge gauge) {
+        gauges.add(gauge);
+    }
+
+    @Override
+    public void unregisterOutstandingRequestsGauge(OutstandingRequestsGauge gauge) {
+        gauges.remove(gauge);
+    }
+
+}

--- a/folsom-micrometer-metrics/src/main/java/com/spotify/folsom/client/MicrometerMetrics.java
+++ b/folsom-micrometer-metrics/src/main/java/com/spotify/folsom/client/MicrometerMetrics.java
@@ -16,6 +16,8 @@
 
 package com.spotify.folsom.client;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.spotify.folsom.GetResult;
 import com.spotify.folsom.MemcacheStatus;
@@ -24,206 +26,213 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
-
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CopyOnWriteArraySet;
 
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-
 public class MicrometerMetrics implements Metrics {
 
-    private final Timer getHits;
-    private final Timer getMisses;
-    private final Timer getFailures;
+  private final Timer getHits;
+  private final Timer getMisses;
+  private final Timer getFailures;
 
-    private final Timer multigetCalls;
-    private final Counter multigetHits;
-    private final Counter multigetMisses;
-    private final Timer multigetFailures;
+  private final Timer multigetCalls;
+  private final Counter multigetHits;
+  private final Counter multigetMisses;
+  private final Timer multigetFailures;
 
-    private final Timer setSuccesses;
-    private final Timer setFailures;
+  private final Timer setSuccesses;
+  private final Timer setFailures;
 
-    private final Timer deleteSuccesses;
-    private final Timer deleteFailures;
+  private final Timer deleteSuccesses;
+  private final Timer deleteFailures;
 
-    private final Timer incrDecrSuccesses;
-    private final Timer incrDecrFailures;
+  private final Timer incrDecrSuccesses;
+  private final Timer incrDecrFailures;
 
-    private final Timer touchSuccesses;
-    private final Timer touchFailures;
+  private final Timer touchSuccesses;
+  private final Timer touchFailures;
 
-    private final Set<OutstandingRequestsGauge> gauges = new CopyOnWriteArraySet<>();
+  private final Set<OutstandingRequestsGauge> gauges = new CopyOnWriteArraySet<>();
 
-    /**
-     *
-     * @param registry MeterRegistry
-     */
-    public MicrometerMetrics(final MeterRegistry registry) {
-        this(registry, Tags.empty());
-    }
+  /** @param registry MeterRegistry */
+  public MicrometerMetrics(final MeterRegistry registry) {
+    this(registry, Tags.empty());
+  }
 
-    /**
-     *
-     * @param registry MeterRegistry
-     * @param tags Additional tags that will be added to each meter
-     */
-    public MicrometerMetrics(final MeterRegistry registry, final String... tags) {
-        this(registry, Tags.of(tags));
-    }
+  /**
+   * @param registry MeterRegistry
+   * @param tags Additional tags that will be added to each meter
+   */
+  public MicrometerMetrics(final MeterRegistry registry, final String... tags) {
+    this(registry, Tags.of(tags));
+  }
 
-    /**
-     *
-     * @param registry MeterRegistry
-     * @param tags Additional tags that will be added to each meter
-     */
-    public MicrometerMetrics(final MeterRegistry registry, final Tags tags) {
-        String meterName = "memcache.requests";
-        this.getHits = registry.timer(meterName, tags.and("operation", "get", "result", "hits"));
-        this.getMisses = registry.timer(meterName, tags.and("operation", "get", "result", "misses"));
-        this.getFailures = registry.timer(meterName, tags.and("operation", "get", "result", "failures"));
+  /**
+   * @param registry MeterRegistry
+   * @param tags Additional tags that will be added to each meter
+   */
+  public MicrometerMetrics(final MeterRegistry registry, final Tags tags) {
+    String meterName = "memcache.requests";
+    this.getHits = registry.timer(meterName, tags.and("operation", "get", "result", "hits"));
+    this.getMisses = registry.timer(meterName, tags.and("operation", "get", "result", "misses"));
+    this.getFailures =
+        registry.timer(meterName, tags.and("operation", "get", "result", "failures"));
 
-        this.multigetCalls = registry.timer(meterName, tags.and("operation", "multiget", "result", "hitsOrMisses"));
-        this.multigetHits = registry.counter(meterName, tags.and("operation", "multiget", "result", "hits"));
-        this.multigetMisses = registry.counter(meterName, tags.and("operation", "multiget", "result", "misses"));
-        this.multigetFailures = registry.timer(meterName, tags.and("operation", "multiget", "result", "failures"));
+    this.multigetCalls =
+        registry.timer(meterName, tags.and("operation", "multiget", "result", "hitsOrMisses"));
+    this.multigetHits =
+        registry.counter(meterName, tags.and("operation", "multiget", "result", "hits"));
+    this.multigetMisses =
+        registry.counter(meterName, tags.and("operation", "multiget", "result", "misses"));
+    this.multigetFailures =
+        registry.timer(meterName, tags.and("operation", "multiget", "result", "failures"));
 
-        this.setSuccesses = registry.timer(meterName, tags.and("operation", "set", "result", "successes"));
-        this.setFailures = registry.timer(meterName, tags.and("operation", "set", "result", "failures"));
+    this.setSuccesses =
+        registry.timer(meterName, tags.and("operation", "set", "result", "successes"));
+    this.setFailures =
+        registry.timer(meterName, tags.and("operation", "set", "result", "failures"));
 
-        this.deleteSuccesses = registry.timer(meterName, tags.and("operation", "delete", "result", "successes"));
-        this.deleteFailures = registry.timer(meterName, tags.and("operation", "delete", "result", "failures"));
+    this.deleteSuccesses =
+        registry.timer(meterName, tags.and("operation", "delete", "result", "successes"));
+    this.deleteFailures =
+        registry.timer(meterName, tags.and("operation", "delete", "result", "failures"));
 
-        this.incrDecrSuccesses = registry.timer(meterName, tags.and("operation", "incrdecr", "result", "successes"));
-        this.incrDecrFailures = registry.timer(meterName, tags.and("operation", "incrdecr", "result", "failures"));
+    this.incrDecrSuccesses =
+        registry.timer(meterName, tags.and("operation", "incrdecr", "result", "successes"));
+    this.incrDecrFailures =
+        registry.timer(meterName, tags.and("operation", "incrdecr", "result", "failures"));
 
-        this.touchSuccesses = registry.timer(meterName, tags.and("operation", "touch", "result", "successes"));
-        this.touchFailures = registry.timer(meterName, tags.and("operation", "touch", "result", "failures"));
+    this.touchSuccesses =
+        registry.timer(meterName, tags.and("operation", "touch", "result", "successes"));
+    this.touchFailures =
+        registry.timer(meterName, tags.and("operation", "touch", "result", "failures"));
 
-        registry.gauge("memcache.outstandingRequests", tags, this, MicrometerMetrics::getOutstandingRequests);
-        registry.gauge("memcache.global.connections", tags, this, o -> Utils.getGlobalConnectionCount());
-    }
+    registry.gauge(
+        "memcache.outstandingRequests", tags, this, MicrometerMetrics::getOutstandingRequests);
+    registry.gauge(
+        "memcache.global.connections", tags, this, o -> Utils.getGlobalConnectionCount());
+  }
 
-    @VisibleForTesting
-    long getOutstandingRequests() {
-        return gauges.stream().mapToLong(OutstandingRequestsGauge::getOutstandingRequests).sum();
-    }
+  @VisibleForTesting
+  long getOutstandingRequests() {
+    return gauges.stream().mapToLong(OutstandingRequestsGauge::getOutstandingRequests).sum();
+  }
 
-    @Override
-    public void measureGetFuture(CompletionStage<GetResult<byte[]>> future) {
-        final long startNs = System.nanoTime();
+  @Override
+  public void measureGetFuture(CompletionStage<GetResult<byte[]>> future) {
+    final long startNs = System.nanoTime();
 
-        future.whenComplete(
-                (result, t) -> {
-                    long duration = System.nanoTime() - startNs;
-                    if (t == null) {
-                        if (result != null) {
-                            getHits.record(duration, NANOSECONDS);
-                        } else {
-                            getMisses.record(duration, NANOSECONDS);
-                        }
-                    } else {
-                        getFailures.record(duration, NANOSECONDS);
-                    }
-                });
-    }
+    future.whenComplete(
+        (result, t) -> {
+          long duration = System.nanoTime() - startNs;
+          if (t == null) {
+            if (result != null) {
+              getHits.record(duration, NANOSECONDS);
+            } else {
+              getMisses.record(duration, NANOSECONDS);
+            }
+          } else {
+            getFailures.record(duration, NANOSECONDS);
+          }
+        });
+  }
 
-    @Override
-    public void measureMultigetFuture(CompletionStage<List<GetResult<byte[]>>> future) {
-        final long startNs = System.nanoTime();
+  @Override
+  public void measureMultigetFuture(CompletionStage<List<GetResult<byte[]>>> future) {
+    final long startNs = System.nanoTime();
 
-        future.whenComplete(
-                (result, t) -> {
-                    long duration = System.nanoTime() - startNs;
-                    if (t == null) {
-                        multigetCalls.record(duration, NANOSECONDS);
+    future.whenComplete(
+        (result, t) -> {
+          long duration = System.nanoTime() - startNs;
+          if (t == null) {
+            multigetCalls.record(duration, NANOSECONDS);
 
-                        int hits = 0;
-                        int total = result.size();
-                        for (GetResult<byte[]> getResult : result) {
-                            if (getResult != null) {
-                                hits++;
-                            }
-                        }
+            int hits = 0;
+            int total = result.size();
+            for (GetResult<byte[]> getResult : result) {
+              if (getResult != null) {
+                hits++;
+              }
+            }
 
-                        multigetHits.increment(hits);
-                        multigetMisses.increment(total - hits);
-                    } else {
-                        multigetFailures.record(duration, NANOSECONDS);;
-                    }
-                });
-    }
+            multigetHits.increment(hits);
+            multigetMisses.increment(total - hits);
+          } else {
+            multigetFailures.record(duration, NANOSECONDS);
+            ;
+          }
+        });
+  }
 
-    @Override
-    public void measureDeleteFuture(CompletionStage<MemcacheStatus> future) {
-        final long startNs = System.nanoTime();
+  @Override
+  public void measureDeleteFuture(CompletionStage<MemcacheStatus> future) {
+    final long startNs = System.nanoTime();
 
-        future.whenComplete(
-                (result, t) -> {
-                    long duration = System.nanoTime() - startNs;
-                    if (t == null) {
-                        deleteSuccesses.record(duration, NANOSECONDS);
-                    } else {
-                        deleteFailures.record(duration, NANOSECONDS);
-                    }
-                });
-    }
+    future.whenComplete(
+        (result, t) -> {
+          long duration = System.nanoTime() - startNs;
+          if (t == null) {
+            deleteSuccesses.record(duration, NANOSECONDS);
+          } else {
+            deleteFailures.record(duration, NANOSECONDS);
+          }
+        });
+  }
 
-    @Override
-    public void measureSetFuture(CompletionStage<MemcacheStatus> future) {
-        final long startNs = System.nanoTime();
+  @Override
+  public void measureSetFuture(CompletionStage<MemcacheStatus> future) {
+    final long startNs = System.nanoTime();
 
-        future.whenComplete(
-                (result, t) -> {
-                    long duration = System.nanoTime() - startNs;
-                    if (t == null) {
-                        setSuccesses.record(duration, NANOSECONDS);
-                    } else {
-                        setFailures.record(duration, NANOSECONDS);
-                    }
-                });
-    }
+    future.whenComplete(
+        (result, t) -> {
+          long duration = System.nanoTime() - startNs;
+          if (t == null) {
+            setSuccesses.record(duration, NANOSECONDS);
+          } else {
+            setFailures.record(duration, NANOSECONDS);
+          }
+        });
+  }
 
-    @Override
-    public void measureIncrDecrFuture(CompletionStage<Long> future) {
-        final long startNs = System.nanoTime();
+  @Override
+  public void measureIncrDecrFuture(CompletionStage<Long> future) {
+    final long startNs = System.nanoTime();
 
-        future.whenComplete(
-                (result, t) -> {
-                    long duration = System.nanoTime() - startNs;
-                    if (t == null) {
-                        incrDecrSuccesses.record(duration, NANOSECONDS);
-                    } else {
-                        incrDecrFailures.record(duration, NANOSECONDS);
-                    }
-                });
-    }
+    future.whenComplete(
+        (result, t) -> {
+          long duration = System.nanoTime() - startNs;
+          if (t == null) {
+            incrDecrSuccesses.record(duration, NANOSECONDS);
+          } else {
+            incrDecrFailures.record(duration, NANOSECONDS);
+          }
+        });
+  }
 
-    @Override
-    public void measureTouchFuture(CompletionStage<MemcacheStatus> future) {
-        final long startNs = System.nanoTime();
+  @Override
+  public void measureTouchFuture(CompletionStage<MemcacheStatus> future) {
+    final long startNs = System.nanoTime();
 
-        future.whenComplete(
-                (result, t) -> {
-                    long duration = System.nanoTime() - startNs;
-                    if (t == null) {
-                        touchSuccesses.record(duration, NANOSECONDS);
-                    } else {
-                        touchFailures.record(duration, NANOSECONDS);
-                    }
-                });
-    }
+    future.whenComplete(
+        (result, t) -> {
+          long duration = System.nanoTime() - startNs;
+          if (t == null) {
+            touchSuccesses.record(duration, NANOSECONDS);
+          } else {
+            touchFailures.record(duration, NANOSECONDS);
+          }
+        });
+  }
 
-    @Override
-    public void registerOutstandingRequestsGauge(OutstandingRequestsGauge gauge) {
-        gauges.add(gauge);
-    }
+  @Override
+  public void registerOutstandingRequestsGauge(OutstandingRequestsGauge gauge) {
+    gauges.add(gauge);
+  }
 
-    @Override
-    public void unregisterOutstandingRequestsGauge(OutstandingRequestsGauge gauge) {
-        gauges.remove(gauge);
-    }
-
+  @Override
+  public void unregisterOutstandingRequestsGauge(OutstandingRequestsGauge gauge) {
+    gauges.remove(gauge);
+  }
 }

--- a/folsom-micrometer-metrics/src/test/java/com/spotify/folsom/client/MicrometerMetricsTest.java
+++ b/folsom-micrometer-metrics/src/test/java/com/spotify/folsom/client/MicrometerMetricsTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.folsom.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.spotify.folsom.AsciiMemcacheClient;
+import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.client.ascii.DefaultAsciiMemcacheClient;
+import com.spotify.folsom.client.test.FakeRawMemcacheClient;
+import com.spotify.folsom.transcoder.StringTranscoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MicrometerMetricsTest {
+
+  private MicrometerMetrics metrics;
+  private SimpleMeterRegistry meterRegistry;
+  private AsciiMemcacheClient<String> client;
+  private FakeRawMemcacheClient fakeRawMemcacheClient;
+
+  @Before
+  public void setUp() throws Exception {
+    setupComponents();
+  }
+
+  private void setupComponents(String... tags) throws Exception {
+    meterRegistry = new SimpleMeterRegistry();
+    if(tags.length == 0) {
+      metrics = new MicrometerMetrics(meterRegistry);
+    } else {
+      metrics = new MicrometerMetrics(meterRegistry, tags);
+    }
+    fakeRawMemcacheClient = new FakeRawMemcacheClient(metrics);
+    client =
+            new DefaultAsciiMemcacheClient<>(
+                    fakeRawMemcacheClient,
+                    metrics,
+                    NoopTracer.INSTANCE,
+                    StringTranscoder.UTF8_INSTANCE,
+                    StandardCharsets.UTF_8,
+                    MemcacheEncoder.MAX_KEY_LEN);
+    client.awaitConnected(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testExtraTags() throws Exception {
+    setupComponents("client", "a");
+
+    assertNull(client.get("key-miss").toCompletableFuture().get());
+    Timer getMisses = meterRegistry.find("memcache.requests")
+            .tag("operation", "get")
+            .tag("result", "misses")
+            .tag("client", "a").timer();
+    assert getMisses != null;
+    awaitCount(1, getMisses);
+  }
+
+
+  @Test
+  public void testGetMiss() throws Exception {
+
+    assertEquals(0, getGetHits().count());
+    assertEquals(0, getGetMisses().count(), 0);
+    assertEquals(0, getGetFailures().count(), 0);
+
+    assertNull(client.get("key-miss").toCompletableFuture().get());
+
+    awaitCount(1, getGetMisses());
+    assertEquals(0, getGetHits().count(), 0);
+    assertEquals(1, getGetMisses().count(), 0);
+    assertEquals(0, getGetFailures().count(), 0);
+  }
+
+  @Test
+  public void testGetHit() throws Exception {
+    assertEquals(0, getGetHits().count(), 0);
+    assertEquals(0, getGetMisses().count(), 0);
+    assertEquals(0, getGetFailures().count(), 0);
+
+    assertEquals(MemcacheStatus.OK, client.set("key", "value", 0).toCompletableFuture().get());
+    assertEquals("value", client.get("key").toCompletableFuture().get());
+
+    assertEquals(1, getGetHits().count(), 0);
+    assertEquals(0, getGetMisses().count(), 0);
+    assertEquals(0, getGetFailures().count(), 0);
+  }
+
+  @Test
+  public void testMultiget() throws Exception {
+    assertEquals(0, getMultigetCalls().count());
+    assertEquals(0, getGetHits().count(), 0);
+    assertEquals(0, getGetMisses().count(), 0);
+    assertEquals(0, getMultigetFailures().count(), 0);
+
+    assertEquals(MemcacheStatus.OK, client.set("key", "value", 0).toCompletableFuture().get());
+    assertEquals(
+        Arrays.asList("value", null),
+        client.get(Arrays.asList("key", "key-miss")).toCompletableFuture().get());
+
+    awaitCount(1, getMultigetCalls());
+    assertEquals(1, getMultigetHits().count(), 0);
+    assertEquals(1, getMultigetMisses().count(), 0);
+    assertEquals(0, getMultigetFailures().count(), 0);
+  }
+
+  @Test
+  public void testSet() throws Exception {
+    assertEquals(0, getSetFailures().count(), 0);
+    assertEquals(0, getSetSuccesses().count(), 0);
+
+    assertEquals(MemcacheStatus.OK, client.set("key", "value", 0).toCompletableFuture().get());
+
+    assertEquals(0, getSetFailures().count(), 0);
+    assertEquals(1, getSetSuccesses().count(), 0);
+  }
+
+  @Test
+  public void testIncrDecr() throws Exception {
+    assertEquals(MemcacheStatus.OK, client.set("key", "0", 0).toCompletableFuture().get());
+
+    assertEquals(0, getIncrDecrFailures().count(), 0);
+    assertEquals(0, getIncrDecrSuccesses().count(), 0);
+
+    assertEquals(Long.valueOf(1L), client.incr("key", 1).toCompletableFuture().get());
+
+    assertEquals(0, getIncrDecrFailures().count(), 0);
+    assertEquals(1, getIncrDecrSuccesses().count(), 0);
+  }
+
+  @Test
+  public void testTouch() throws Exception {
+    assertEquals(MemcacheStatus.OK, client.set("key", "0", 0).toCompletableFuture().get());
+
+    assertEquals(0, getTouchFailures().count(), 0);
+    assertEquals(0, getTouchSuccesses().count(), 0);
+
+    assertEquals(MemcacheStatus.OK, client.touch("key", 1).toCompletableFuture().get());
+
+    assertEquals(0, getTouchFailures().count(), 0);
+    assertEquals(1, getTouchSuccesses().count(), 0);
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    assertEquals(0, getDeleteFailures().count(), 0);
+    assertEquals(0, getDeleteSuccesses().count(), 0);
+
+    assertEquals(MemcacheStatus.OK, client.delete("key").toCompletableFuture().get());
+
+    assertEquals(0, getDeleteFailures().count(), 0);
+    assertEquals(1, getDeleteSuccesses().count(), 0);
+  }
+
+  /** Test wiring up of OutstandingRequestGauge to the Yammer-metrics gauge. */
+  @Test
+  public void testOutstandingRequests() {
+    // baseline
+    assertEquals(0L, metrics.getOutstandingRequests());
+
+    fakeRawMemcacheClient.setOutstandingRequests(5);
+    assertEquals(5L, metrics.getOutstandingRequests());
+
+    fakeRawMemcacheClient.setOutstandingRequests(0);
+    assertEquals(0L, metrics.getOutstandingRequests());
+  }
+
+  private void awaitCount(int expectedValue, Timer timer) throws InterruptedException {
+    final int timeout = 10;
+    final long t1 = System.currentTimeMillis();
+    while (expectedValue != timer.count()) {
+      if (System.currentTimeMillis() - t1 > timeout) {
+        assertEquals(expectedValue, timer.count());
+        return;
+      }
+      Thread.sleep(0, 100);
+    }
+  }
+
+//        registry.gauge("memcache.outstandingRequests", tags, this, MicrometerMetrics::getOutstandingRequests);
+//        registry.gauge("memcache.global.connections", tags, this, o -> Utils.getGlobalConnectionCount());
+
+
+  private Timer getGetHits() {
+    return meterRegistry.find("memcache.requests").tag("operation", "get").tag("result", "hits").timer();
+  }
+
+  private Timer getGetMisses() {
+    return meterRegistry.find("memcache.requests").tag("operation", "get").tag("result", "misses").timer();
+  }
+
+  private Timer getGetFailures() {
+    return meterRegistry.find("memcache.requests").tag("operation", "get").tag("result", "failures").timer();
+  }
+
+  private Timer getMultigetCalls() {
+    return meterRegistry.find("memcache.requests").tag("operation", "multiget").tag("result", "hitsOrMisses").timer();
+  }
+
+  private Counter getMultigetHits() {
+    return meterRegistry.find("memcache.requests").tag("operation", "multiget").tag("result", "hits").counter();
+  }
+
+  private Counter getMultigetMisses() {
+    return meterRegistry.find("memcache.requests").tag("operation", "multiget").tag("result", "misses").counter();
+  }
+
+  private Timer getMultigetFailures() {
+    return meterRegistry.find("memcache.requests").tag("operation", "multiget").tag("result", "failures").timer();
+  }
+
+  private Timer getSetSuccesses() {
+    return meterRegistry.find("memcache.requests").tag("operation", "set").tag("result", "successes").timer();
+  }
+
+  private Timer getSetFailures() {
+    return meterRegistry.find("memcache.requests").tag("operation", "set").tag("result", "failures").timer();
+  }
+
+  private Timer getDeleteSuccesses() {
+    return meterRegistry.find("memcache.requests").tag("operation", "delete").tag("result", "successes").timer();
+  }
+
+  private Timer getDeleteFailures() {
+    return meterRegistry.find("memcache.requests").tag("operation", "delete").tag("result", "failures").timer();
+  }
+
+  private Timer getIncrDecrSuccesses() {
+    return meterRegistry.find("memcache.requests").tag("operation", "incrdecr").tag("result", "successes").timer();
+  }
+
+  private Timer getIncrDecrFailures() {
+    return meterRegistry.find("memcache.requests").tag("operation", "incrdecr").tag("result", "failures").timer();
+  }
+
+  private Timer getTouchSuccesses() {
+    return meterRegistry.find("memcache.requests").tag("operation", "touch").tag("result", "successes").timer();
+  }
+
+  private Timer getTouchFailures() {
+    return meterRegistry.find("memcache.requests").tag("operation", "touch").tag("result", "failures").timer();
+  }
+
+}

--- a/folsom-micrometer-metrics/src/test/java/com/spotify/folsom/client/MicrometerMetricsTest.java
+++ b/folsom-micrometer-metrics/src/test/java/com/spotify/folsom/client/MicrometerMetricsTest.java
@@ -199,10 +199,6 @@ public class MicrometerMetricsTest {
     }
   }
 
-//        registry.gauge("memcache.outstandingRequests", tags, this, MicrometerMetrics::getOutstandingRequests);
-//        registry.gauge("memcache.global.connections", tags, this, o -> Utils.getGlobalConnectionCount());
-
-
   private Timer getGetHits() {
     return meterRegistry.find("memcache.requests").tag("operation", "get").tag("result", "hits").timer();
   }

--- a/folsom-micrometer-metrics/src/test/java/com/spotify/folsom/client/MicrometerMetricsTest.java
+++ b/folsom-micrometer-metrics/src/test/java/com/spotify/folsom/client/MicrometerMetricsTest.java
@@ -23,14 +23,12 @@ import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.ascii.DefaultAsciiMemcacheClient;
 import com.spotify.folsom.client.test.FakeRawMemcacheClient;
 import com.spotify.folsom.transcoder.StringTranscoder;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,20 +46,20 @@ public class MicrometerMetricsTest {
 
   private void setupComponents(String... tags) throws Exception {
     meterRegistry = new SimpleMeterRegistry();
-    if(tags.length == 0) {
+    if (tags.length == 0) {
       metrics = new MicrometerMetrics(meterRegistry);
     } else {
       metrics = new MicrometerMetrics(meterRegistry, tags);
     }
     fakeRawMemcacheClient = new FakeRawMemcacheClient(metrics);
     client =
-            new DefaultAsciiMemcacheClient<>(
-                    fakeRawMemcacheClient,
-                    metrics,
-                    NoopTracer.INSTANCE,
-                    StringTranscoder.UTF8_INSTANCE,
-                    StandardCharsets.UTF_8,
-                    MemcacheEncoder.MAX_KEY_LEN);
+        new DefaultAsciiMemcacheClient<>(
+            fakeRawMemcacheClient,
+            metrics,
+            NoopTracer.INSTANCE,
+            StringTranscoder.UTF8_INSTANCE,
+            StandardCharsets.UTF_8,
+            MemcacheEncoder.MAX_KEY_LEN);
     client.awaitConnected(10, TimeUnit.SECONDS);
   }
 
@@ -70,14 +68,16 @@ public class MicrometerMetricsTest {
     setupComponents("client", "a");
 
     assertNull(client.get("key-miss").toCompletableFuture().get());
-    Timer getMisses = meterRegistry.find("memcache.requests")
+    Timer getMisses =
+        meterRegistry
+            .find("memcache.requests")
             .tag("operation", "get")
             .tag("result", "misses")
-            .tag("client", "a").timer();
+            .tag("client", "a")
+            .timer();
     assert getMisses != null;
     awaitCount(1, getMisses);
   }
-
 
   @Test
   public void testGetMiss() throws Exception {
@@ -200,63 +200,122 @@ public class MicrometerMetricsTest {
   }
 
   private Timer getGetHits() {
-    return meterRegistry.find("memcache.requests").tag("operation", "get").tag("result", "hits").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "get")
+        .tag("result", "hits")
+        .timer();
   }
 
   private Timer getGetMisses() {
-    return meterRegistry.find("memcache.requests").tag("operation", "get").tag("result", "misses").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "get")
+        .tag("result", "misses")
+        .timer();
   }
 
   private Timer getGetFailures() {
-    return meterRegistry.find("memcache.requests").tag("operation", "get").tag("result", "failures").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "get")
+        .tag("result", "failures")
+        .timer();
   }
 
   private Timer getMultigetCalls() {
-    return meterRegistry.find("memcache.requests").tag("operation", "multiget").tag("result", "hitsOrMisses").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "multiget")
+        .tag("result", "hitsOrMisses")
+        .timer();
   }
 
   private Counter getMultigetHits() {
-    return meterRegistry.find("memcache.requests").tag("operation", "multiget").tag("result", "hits").counter();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "multiget")
+        .tag("result", "hits")
+        .counter();
   }
 
   private Counter getMultigetMisses() {
-    return meterRegistry.find("memcache.requests").tag("operation", "multiget").tag("result", "misses").counter();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "multiget")
+        .tag("result", "misses")
+        .counter();
   }
 
   private Timer getMultigetFailures() {
-    return meterRegistry.find("memcache.requests").tag("operation", "multiget").tag("result", "failures").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "multiget")
+        .tag("result", "failures")
+        .timer();
   }
 
   private Timer getSetSuccesses() {
-    return meterRegistry.find("memcache.requests").tag("operation", "set").tag("result", "successes").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "set")
+        .tag("result", "successes")
+        .timer();
   }
 
   private Timer getSetFailures() {
-    return meterRegistry.find("memcache.requests").tag("operation", "set").tag("result", "failures").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "set")
+        .tag("result", "failures")
+        .timer();
   }
 
   private Timer getDeleteSuccesses() {
-    return meterRegistry.find("memcache.requests").tag("operation", "delete").tag("result", "successes").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "delete")
+        .tag("result", "successes")
+        .timer();
   }
 
   private Timer getDeleteFailures() {
-    return meterRegistry.find("memcache.requests").tag("operation", "delete").tag("result", "failures").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "delete")
+        .tag("result", "failures")
+        .timer();
   }
 
   private Timer getIncrDecrSuccesses() {
-    return meterRegistry.find("memcache.requests").tag("operation", "incrdecr").tag("result", "successes").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "incrdecr")
+        .tag("result", "successes")
+        .timer();
   }
 
   private Timer getIncrDecrFailures() {
-    return meterRegistry.find("memcache.requests").tag("operation", "incrdecr").tag("result", "failures").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "incrdecr")
+        .tag("result", "failures")
+        .timer();
   }
 
   private Timer getTouchSuccesses() {
-    return meterRegistry.find("memcache.requests").tag("operation", "touch").tag("result", "successes").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "touch")
+        .tag("result", "successes")
+        .timer();
   }
 
   private Timer getTouchFailures() {
-    return meterRegistry.find("memcache.requests").tag("operation", "touch").tag("result", "failures").timer();
+    return meterRegistry
+        .find("memcache.requests")
+        .tag("operation", "touch")
+        .tag("result", "failures")
+        .timer();
   }
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
     <module>folsom</module>
     <module>folsom-semantic-metrics</module>
     <module>folsom-yammer-metrics</module>
+    <module>folsom-micrometer-metrics</module>
     <module>folsom-opencensus</module>
     <module>folsom-elasticache</module>
     <module>bom</module>


### PR DESCRIPTION
Addresses #185 by adding micrometer metrics.

One difference to the Yammer based approach is that operations and results are tags, which will allow for combining meters on the same chart easily.