### PR TITLE
Move duplicate method to the Request interface

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/AllRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/AllRequest.java
@@ -43,6 +43,4 @@ public interface AllRequest<T> extends Request<T> {
     results.forEach(builder::putAll);
     return builder.build();
   }
-
-  Request<T> duplicate();
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/Request.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/Request.java
@@ -18,5 +18,7 @@ public interface Request<V> {
 
   void handle(Object msg, HostAndPort address) throws IOException;
 
-  Request<V> duplicate();
+  default Request<V> duplicate() {
+    throw new RuntimeException("duplicate not implemented");
+  }
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/Request.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/Request.java
@@ -17,4 +17,6 @@ public interface Request<V> {
   ByteBuf writeRequest(ByteBufAllocator alloc, ByteBuffer workingBuffer);
 
   void handle(Object msg, HostAndPort address) throws IOException;
+
+  Request<V> duplicate();
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/DeleteRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/DeleteRequest.java
@@ -17,6 +17,7 @@
 package com.spotify.folsom.client.ascii;
 
 import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -38,6 +39,11 @@ public class DeleteRequest extends AsciiRequest<MemcacheStatus> {
     dst.put(key);
     dst.put(NEWLINE_BYTES);
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<MemcacheStatus> duplicate() {
+    return new DeleteRequest(key);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/DeleteWithCasRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/DeleteWithCasRequest.java
@@ -19,6 +19,7 @@ package com.spotify.folsom.client.ascii;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -53,6 +54,11 @@ public class DeleteWithCasRequest extends AsciiRequest<MemcacheStatus> {
     dst.put(String.valueOf(cas).getBytes());
     dst.put(VALUE_BYTES);
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<MemcacheStatus> duplicate() {
+    return new DeleteWithCasRequest(key, cas);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/GetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/GetRequest.java
@@ -17,6 +17,7 @@
 package com.spotify.folsom.client.ascii;
 
 import com.spotify.folsom.GetResult;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -45,6 +46,11 @@ public class GetRequest extends AsciiRequest<GetResult<byte[]>>
     dst.put(key);
     dst.put(NEWLINE_BYTES);
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<GetResult<byte[]>> duplicate() {
+    return new GetRequest(key, this.cmd == CAS_GET);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/IncrRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/IncrRequest.java
@@ -16,6 +16,7 @@
 
 package com.spotify.folsom.client.ascii;
 
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.ascii.AsciiResponse.Type;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
@@ -55,6 +56,11 @@ public class IncrRequest extends AsciiRequest<Long> {
     dst.put(String.valueOf(by).getBytes());
     dst.put(NEWLINE_BYTES);
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<Long> duplicate() {
+    return new IncrRequest(operation, key, by);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/MultigetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/MultigetRequest.java
@@ -67,6 +67,11 @@ public class MultigetRequest extends AsciiRequest<List<GetResult<byte[]>>>
   }
 
   @Override
+  public Request<List<GetResult<byte[]>>> duplicate() {
+    return new MultigetRequest(keys, cmd);
+  }
+
+  @Override
   public void handle(AsciiResponse response, final HostAndPort server) throws IOException {
     final int size = keys.size();
     final List<GetResult<byte[]>> result = new ArrayList<>(size);

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
@@ -19,6 +19,7 @@ package com.spotify.folsom.client.ascii;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.Utils;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
@@ -104,6 +105,11 @@ public class SetRequest extends AsciiRequest<MemcacheStatus>
     } else {
       return toBufferWithValueAndNewLine(alloc, dst, value);
     }
+  }
+
+  @Override
+  public Request<MemcacheStatus> duplicate() {
+    return new SetRequest(operation, key, value, ttl, cas, flags);
   }
 
   private static ByteBuf toBufferWithValueAndNewLine(

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/TouchRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/TouchRequest.java
@@ -16,6 +16,7 @@
 package com.spotify.folsom.client.ascii;
 
 import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.Utils;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
@@ -41,6 +42,11 @@ public class TouchRequest extends AsciiRequest<MemcacheStatus> {
     dst.put(String.valueOf(Utils.ttlToExpiration(ttl)).getBytes());
     dst.put(NEWLINE_BYTES);
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<MemcacheStatus> duplicate() {
+    return new TouchRequest(key, ttl);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/DeleteRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/DeleteRequest.java
@@ -18,6 +18,7 @@ package com.spotify.folsom.client.binary;
 
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.OpCode;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -39,6 +40,11 @@ public class DeleteRequest extends BinaryRequest<MemcacheStatus> {
     writeHeader(dst, OpCode.DELETE, (byte) 0, 0, cas);
     dst.put(key);
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<MemcacheStatus> duplicate() {
+    return new DeleteRequest(key, cas);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/GetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/GetRequest.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import com.spotify.folsom.GetResult;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.OpCode;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.Utils;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
@@ -57,6 +58,11 @@ public class GetRequest extends BinaryRequest<GetResult<byte[]>>
     }
     dst.put(key);
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<GetResult<byte[]>> duplicate() {
+    return new GetRequest(key, opcode, ttl);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/IncrRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/IncrRequest.java
@@ -19,6 +19,7 @@ package com.spotify.folsom.client.binary;
 import com.google.common.primitives.Longs;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.OpCode;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.Utils;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
@@ -53,6 +54,11 @@ public class IncrRequest extends BinaryRequest<Long> {
     dst.putInt(expiration);
     dst.put(key);
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<Long> duplicate() {
+    return new IncrRequest(key, opcode, by, initial, ttl);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/MultigetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/MultigetRequest.java
@@ -94,6 +94,11 @@ public class MultigetRequest extends BinaryRequest<List<GetResult<byte[]>>>
   }
 
   @Override
+  public Request<List<GetResult<byte[]>>> duplicate() {
+    return new MultigetRequest(keys, ttl);
+  }
+
+  @Override
   public void handle(BinaryResponse replies, final HostAndPort server) throws IOException {
     final int size = keys.size();
 

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/NoopRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/NoopRequest.java
@@ -19,6 +19,7 @@ package com.spotify.folsom.client.binary;
 import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.OpCode;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -48,6 +49,11 @@ public class NoopRequest extends BinaryRequest<Void> {
     dst.putInt(opaque); // byte 12-15, Opaque
     dst.putLong((long) 0); // byte 16-23, CAS
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<Void> duplicate() {
+    return new NoopRequest();
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/PlaintextAuthenticateRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/PlaintextAuthenticateRequest.java
@@ -23,6 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.OpCode;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -61,6 +62,11 @@ public class PlaintextAuthenticateRequest extends BinaryRequest<MemcacheStatus> 
     dst.put(password.getBytes(StandardCharsets.US_ASCII));
 
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<MemcacheStatus> duplicate() {
+    return new PlaintextAuthenticateRequest(username, password);
   }
 
   @Override

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/SetRequest.java
@@ -18,6 +18,7 @@ package com.spotify.folsom.client.binary;
 
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.OpCode;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.Utils;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
@@ -72,6 +73,11 @@ public class SetRequest extends BinaryRequest<MemcacheStatus>
     } else {
       return toBufferWithValue(alloc, dst, value);
     }
+  }
+
+  @Override
+  public Request<MemcacheStatus> duplicate() {
+    return new SetRequest(opcode, key, value, ttl, cas, flags);
   }
 
   private static ByteBuf toBufferWithValue(

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/TouchRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/TouchRequest.java
@@ -18,6 +18,7 @@ package com.spotify.folsom.client.binary;
 
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.OpCode;
+import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.Utils;
 import com.spotify.folsom.guava.HostAndPort;
 import io.netty.buffer.ByteBuf;
@@ -44,6 +45,11 @@ public class TouchRequest extends BinaryRequest<MemcacheStatus> {
     dst.put(key);
 
     return toBuffer(alloc, dst);
+  }
+
+  @Override
+  public Request<MemcacheStatus> duplicate() {
+    return new TouchRequest(key, ttl);
   }
 
   @Override

--- a/folsom/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
@@ -155,6 +155,11 @@ public class DefaultRawMemcacheClientTest {
                   dst.put(NEWLINE_BYTES);
                   return toBuffer(alloc, dst);
                 }
+
+                @Override
+                public Request<String> duplicate() {
+                  return this;
+                }
               })
           .toCompletableFuture()
           .get();

--- a/folsom/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/DefaultRawMemcacheClientTest.java
@@ -155,11 +155,6 @@ public class DefaultRawMemcacheClientTest {
                   dst.put(NEWLINE_BYTES);
                   return toBuffer(alloc, dst);
                 }
-
-                @Override
-                public Request<String> duplicate() {
-                  return this;
-                }
               })
           .toCompletableFuture()
           .get();


### PR DESCRIPTION
This change allows to easily duplicate any request.