### PR TITLE
Re-add public methods that were accidentally removed

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
@@ -66,8 +66,18 @@ public class SetRequest extends AsciiRequest<MemcacheStatus>
   }
 
   public static SetRequest casSet(
+      final byte[] key, final byte[] value, final int ttl, final long cas) {
+    return casSet(key, value, ttl, cas, 0);
+  }
+
+  public static SetRequest casSet(
       final byte[] key, final byte[] value, final int ttl, final long cas, final int flags) {
     return new SetRequest(Operation.CAS, key, value, ttl, cas, flags);
+  }
+
+  public static SetRequest create(
+      final Operation operation, final byte[] key, final byte[] value, final int ttl) {
+    return create(operation, key, value, ttl, 0);
   }
 
   public static SetRequest create(

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/SetRequest.java
@@ -36,6 +36,11 @@ public class SetRequest extends BinaryRequest<MemcacheStatus>
   private final int flags;
 
   public SetRequest(
+      final OpCode opcode, final byte[] key, final byte[] value, final int ttl, final long cas) {
+    this(opcode, key, value, ttl, cas, 0);
+  }
+
+  public SetRequest(
       final OpCode opcode,
       final byte[] key,
       final byte[] value,


### PR DESCRIPTION
Some public methods were removed by commit ffccd71af5fef6809fff65ba34601d5d5c65d8fc
Although these methods are marked as public, they are intended to be used by Folsom internally.

However, since they are technically still public and were found to have been called from
non-folsom code it makes sense to re-add them.