### PR TITLE
feat: support generic Serializable type on client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To import it with maven, use this:
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>folsom-bom</artifactId>
-      <version>1.9.0</version>
+      <version>1.12.2</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -108,6 +108,27 @@ client.shutdown();
 
 Clients are single use, after `shutdown` has been invoked the client can no
 longer be used.
+
+#### To work with generic `Serializable` types
+
+One can simply use `MemcacheClientBuilder.<T>newSerializableObjectClient()`
+method to create a client that works for a specific Java type that implements `Serializable`.
+
+```java
+public record Student(String name, int age) implements Serializable { }
+
+public static void main(String[] args) throws Exception {
+  MemcacheClient<Student> client =
+      MemcacheClientBuilder.<Student>newSerializableObjectClient()
+      .withAddress("localhost")
+      .connectAscii();
+  // make it wait until the client has connected to the server
+  ConnectFuture.connectFuture(client).toCompletableFuture().get();
+
+  client.set("s1", new Student("Elon", 28), 10000).toCompletableFuture().get();
+  Student value = client.get("s1").toCompletableFuture().get();
+}
+```
 
 ### Java 7 usage
 

--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -59,7 +59,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-public class MemcacheClientBuilder<V extends Serializable> {
+public class MemcacheClientBuilder<V> {
 
   private static final int DEFAULT_MAX_SET_LENGTH = 1024 * 1024;
 

--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -152,7 +152,7 @@ public class MemcacheClientBuilder<V> {
    * @return The builder
    */
   public static <T extends Serializable> MemcacheClientBuilder<T> newSerializableObjectClient() {
-    return new MemcacheClientBuilder<>(SerializableObjectTranscoder.createInstance());
+    return new MemcacheClientBuilder<>(SerializableObjectTranscoder.getInstance());
   }
 
   /**

--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -59,7 +59,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-public class MemcacheClientBuilder<V> {
+public class MemcacheClientBuilder<V extends Serializable> {
 
   private static final int DEFAULT_MAX_SET_LENGTH = 1024 * 1024;
 
@@ -151,8 +151,8 @@ public class MemcacheClientBuilder<V> {
    *
    * @return The builder
    */
-  public static MemcacheClientBuilder<Serializable> newSerializableObjectClient() {
-    return new MemcacheClientBuilder<>(SerializableObjectTranscoder.INSTANCE);
+  public static <T extends Serializable> MemcacheClientBuilder<T> newSerializableObjectClient() {
+    return new MemcacheClientBuilder<>(SerializableObjectTranscoder.createInstance());
   }
 
   /**

--- a/folsom/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
+++ b/folsom/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
@@ -21,8 +21,11 @@ import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
 
 public final class SerializableObjectTranscoder<T extends Serializable> implements Transcoder<T> {
+
+  public static final SerializableObjectTranscoder INSTANCE = new SerializableObjectTranscoder<>();
+
   public static <T extends Serializable> SerializableObjectTranscoder<T> createInstance() {
-    return new SerializableObjectTranscoder<>();
+    return INSTANCE;
   }
 
   private SerializableObjectTranscoder() {}

--- a/folsom/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
+++ b/folsom/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
@@ -24,7 +24,7 @@ public final class SerializableObjectTranscoder<T extends Serializable> implemen
 
   public static final SerializableObjectTranscoder INSTANCE = new SerializableObjectTranscoder<>();
 
-  public static <T extends Serializable> SerializableObjectTranscoder<T> createInstance() {
+  public static <T extends Serializable> SerializableObjectTranscoder<T> getInstance() {
     return INSTANCE;
   }
 

--- a/folsom/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
+++ b/folsom/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
@@ -20,9 +20,13 @@ import com.spotify.folsom.Transcoder;
 import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
 
-public final class SerializableObjectTranscoder implements Transcoder<Serializable> {
+public final class SerializableObjectTranscoder<T extends Serializable> implements Transcoder<T> {
 
-  public static final SerializableObjectTranscoder INSTANCE = new SerializableObjectTranscoder();
+  public static final SerializableObjectTranscoder INSTANCE = new SerializableObjectTranscoder<>();
+
+  public static <T extends Serializable> SerializableObjectTranscoder<T> createInstance() {
+    return new SerializableObjectTranscoder<>();
+  }
 
   private SerializableObjectTranscoder() {}
 
@@ -32,7 +36,7 @@ public final class SerializableObjectTranscoder implements Transcoder<Serializab
   }
 
   @Override
-  public Serializable decode(final byte[] b) {
-    return (Serializable) SerializationUtils.deserialize(b);
+  public T decode(final byte[] b) {
+    return (T) SerializationUtils.deserialize(b);
   }
 }

--- a/folsom/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
+++ b/folsom/src/main/java/com/spotify/folsom/transcoder/SerializableObjectTranscoder.java
@@ -21,9 +21,6 @@ import java.io.Serializable;
 import org.apache.commons.lang.SerializationUtils;
 
 public final class SerializableObjectTranscoder<T extends Serializable> implements Transcoder<T> {
-
-  public static final SerializableObjectTranscoder INSTANCE = new SerializableObjectTranscoder<>();
-
   public static <T extends Serializable> SerializableObjectTranscoder<T> createInstance() {
     return new SerializableObjectTranscoder<>();
   }

--- a/folsom/src/test/java/com/spotify/folsom/transcoder/SerializableObjectTranscoderTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/transcoder/SerializableObjectTranscoderTest.java
@@ -36,9 +36,10 @@ public class SerializableObjectTranscoderTest {
     b.value2 = "world";
     b.value3 = 5;
 
-    final byte[] encoded = SerializableObjectTranscoder.INSTANCE.encode(b);
-    final SerializableTestObject testObject =
-        (SerializableTestObject) SerializableObjectTranscoder.INSTANCE.decode(encoded);
+    SerializableObjectTranscoder<SerializableTestObject> instance =
+        SerializableObjectTranscoder.createInstance();
+    final byte[] encoded = instance.encode(b);
+    final SerializableTestObject testObject = instance.decode(encoded);
 
     assertEquals("hello", testObject.value1);
     assertEquals("world", testObject.value2);

--- a/folsom/src/test/java/com/spotify/folsom/transcoder/SerializableObjectTranscoderTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/transcoder/SerializableObjectTranscoderTest.java
@@ -37,7 +37,7 @@ public class SerializableObjectTranscoderTest {
     b.value3 = 5;
 
     SerializableObjectTranscoder<SerializableTestObject> instance =
-        SerializableObjectTranscoder.createInstance();
+        SerializableObjectTranscoder.getInstance();
     final byte[] encoded = instance.encode(b);
     final SerializableTestObject testObject = instance.decode(encoded);
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers</artifactId>
-        <version>1.15.1</version>
+        <version>1.16.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Support generic Serializable type on client

Current implementation is not that convenient when creating a client with `newSerializableObjectClient()` as it returns a `MemcacheClient<Serializable>`, which gives the following error when a user trying to use it with a generic type
![image](https://user-images.githubusercontent.com/161689/156359754-5363f9bd-b89c-4eaa-93d7-3d35301b6564.png)

So one has to write it as this to make it compile:
```java
  public record Student(String name, int age) implements Serializable { }

  public static void main(String[] args) throws Exception {
    MemcacheClient<Serializable> client =
        MemcacheClientBuilder.<Student>newSerializableObjectClient()
        .withAddress("localhost")
        .connectAscii();
    // make it wait until the client has connected to the server
    ConnectFuture.connectFuture(client).toCompletableFuture().get();

    client.set("key", new Student("fuyang", 28), 10000).toCompletableFuture().get();
    Student value = (Student) client.get("key").toCompletableFuture().get();
  }
```

This proposed change let `newSerializableObjectClient()` returns a `MemcacheClient<T extends Serializable>` instead, making the user much easier to use a client with a type that is implemented Serializable.

So after this change, a user can do:
```java
  public record Student(String name, int age) implements Serializable { }

  public static void main(String[] args) throws Exception {
    MemcacheClient<Student> client =
        MemcacheClientBuilder.<Student>newSerializableObjectClient()
        .withAddress("localhost")
        .connectAscii();
    // make it wait until the client has connected to the server
    ConnectFuture.connectFuture(client).toCompletableFuture().get();

    client.set("key", new Student("fuyang", 28), 10000).toCompletableFuture().get();
    Student value = client.get("key").toCompletableFuture().get();
  }
```

Plus testcontainers is updated to allow tests to run nicely on M1 machines.