### PR TITLE
docs: update readme serializable exp to use binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ public static void main(String[] args) throws Exception {
   MemcacheClient<Student> client =
       MemcacheClientBuilder.<Student>newSerializableObjectClient()
       .withAddress("localhost")
-      .connectAscii();
+      .connectBinary();
   // make it wait until the client has connected to the server
   ConnectFuture.connectFuture(client).toCompletableFuture().get();
 


### PR DESCRIPTION
A serializable client will store serialized Java object as binary and it doesn't really
make sense to create a AsciiMemcacheClient and the incr and decr operation won't work either.
While the binary client's incr/decr can still be used (if get/set are not used together on those keys) as an initial value can be provided for it.