### PR TITLE
Fix maxSetLength

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java
@@ -223,8 +223,8 @@ public class DefaultRawMemcacheClient extends AbstractRawMemcacheClient {
   public <T> CompletionStage<T> send(final Request<T> request) {
     if (request instanceof SetRequest) {
       SetRequest setRequest = (SetRequest) request;
-      byte[] value = setRequest.getValue();
-      if (value.length > maxSetLength) {
+      int margin = 40; // see MaxSetLengthTest
+      if (setRequest.size() > maxSetLength - margin) {
         return (CompletionStage<T>)
             onExecutor(CompletableFuture.completedFuture(MemcacheStatus.VALUE_TOO_LARGE));
       }

--- a/folsom/src/main/java/com/spotify/folsom/client/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/SetRequest.java
@@ -17,4 +17,6 @@ package com.spotify.folsom.client;
 
 public interface SetRequest {
   byte[] getValue();
+
+  int size();
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
@@ -176,4 +176,21 @@ public class SetRequest extends AsciiRequest<MemcacheStatus>
   public byte[] getValue() {
     return value;
   }
+
+  @Override
+  public int size() {
+    // this size must be consistent with the number of bytes written by writeRequest
+    int size = CMD.get(operation).length;
+    size += key.length;
+    size += toFlags(flags).length;
+    size += String.valueOf(Utils.ttlToExpiration(ttl)).getBytes().length + 1;
+    size += String.valueOf(value.length).getBytes().length;
+    if (operation == Operation.CAS) {
+      size += String.valueOf(cas).getBytes().length + 1;
+    }
+    size += NEWLINE_BYTES.length;
+    size += value.length;
+    size += NEWLINE_BYTES.length;
+    return size;
+  }
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/binary/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/binary/SetRequest.java
@@ -60,10 +60,7 @@ public class SetRequest extends BinaryRequest<MemcacheStatus>
     final int expiration = Utils.ttlToExpiration(ttl);
 
     final int valueLength = value.length;
-
-    final boolean hasExtra =
-        (opcode == OpCode.SET || opcode == OpCode.ADD || opcode == OpCode.REPLACE);
-
+    final boolean hasExtra = hasExtraLength();
     final int extraLength = hasExtra ? 8 : 0;
 
     writeHeader(dst, opcode, extraLength, valueLength, cas);
@@ -78,6 +75,10 @@ public class SetRequest extends BinaryRequest<MemcacheStatus>
     } else {
       return toBufferWithValue(alloc, dst, value);
     }
+  }
+
+  private boolean hasExtraLength() {
+    return opcode == OpCode.SET || opcode == OpCode.ADD || opcode == OpCode.REPLACE;
   }
 
   @Override
@@ -115,5 +116,14 @@ public class SetRequest extends BinaryRequest<MemcacheStatus>
   @Override
   public byte[] getValue() {
     return value;
+  }
+
+  @Override
+  public int size() {
+    // this size must be consistent with the number of bytes written by writeRequest
+    return BinaryRequest.HEADER_SIZE
+        + (hasExtraLength() ? 2 * Integer.BYTES : 0)
+        + key.length
+        + value.length;
   }
 }

--- a/folsom/src/test/java/com/spotify/folsom/client/MaxSetLengthTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/client/MaxSetLengthTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2015 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.folsom.client;
+
+import static org.junit.Assert.fail;
+
+import com.spotify.folsom.*;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.junit.Test;
+
+/**
+ * This test makes sure that we don't send too large items to memcached server, to avoid server
+ * errors and unnecessary reconnections. For some reason there is a discrepancy between the request
+ * size we calculate and the max enforced by memcached, hence the need of the magic number in method
+ * DefaultRawMemcacheClient#send. The max item size actually enforced by memcached is slightly
+ * smaller than the argument given at server start, and it varies depending on binary/ascii protocol
+ * and the value of max item size which with the server was started. This test starts memcached
+ * servers with different values of max item size and sends SET requests that are too large,
+ * decreasing them byte by byte, until the request is successful, validating that we never send a
+ * request too large to the server, request sizes are limited in the client.
+ *
+ * @see DefaultRawMemcacheClient#send
+ */
+public class MaxSetLengthTest {
+
+  @Test
+  public void testMaxItemSizes() throws Exception {
+    double[] maxItemSizeFactors = new double[] {0.5, 1, 2, 4};
+
+    for (double factor : maxItemSizeFactors) {
+      int maxItemSize = (int) (1024 * 1024 * factor);
+
+      MemcachedServer server = startMemcached(maxItemSize);
+
+      AsciiMemcacheClient<String> asciiClient = clientBuilder(server, maxItemSize).connectAscii();
+      testMaxItemSize(asciiClient, maxItemSize);
+      asciiClient.shutdown();
+
+      BinaryMemcacheClient<String> binaryClient =
+          clientBuilder(server, maxItemSize).connectBinary();
+      testMaxItemSize(binaryClient, maxItemSize);
+      binaryClient.shutdown();
+
+      server.stop();
+    }
+  }
+
+  MemcachedServer startMemcached(int maxItemSize) {
+    return new MemcachedServer(null, null, Optional.empty(), Optional.of(maxItemSize));
+  }
+
+  MemcacheClientBuilder<String> clientBuilder(MemcachedServer server, int maxItemSize) {
+    return MemcacheClientBuilder.<String>newSerializableObjectClient()
+        .withAddress(server.getHost(), server.getPort())
+        .withMaxSetLength(maxItemSize);
+  }
+
+  void testMaxItemSize(MemcacheClient<String> client, int maxItemSize) throws Exception {
+    ConnectFuture.connectFuture(client).toCompletableFuture().get();
+    boolean ok = false;
+    for (int itemSize = maxItemSize; !ok; itemSize--) {
+      String value = getValue(itemSize);
+      MemcacheStatus status = null;
+      try {
+        status = client.set("somekey", value, 1000).toCompletableFuture().get();
+      } catch (ExecutionException e) {
+        fail(e.getCause().toString());
+      }
+      ok = MemcacheStatus.OK == status;
+    }
+  }
+
+  String getValue(int size) {
+    byte[] bytes = new byte[size];
+    Arrays.fill(bytes, (byte) 42);
+    return new String(bytes);
+  }
+}


### PR DESCRIPTION
Memcached has a limit on the size of the value, which is by default 1MB. However, iiuc, this limit is not just for the value but for the whole request (key + value + flags + cas). 
As far as I can tell,  it is checked [here](https://github.com/memcached/memcached/blob/046c4bb5d8498420c13e5357c8299b60952b2595/proto_text.c#L1971-L1973), which calls [item_size_ok](https://github.com/memcached/memcached/blob/4b23988acb2151de8009d0ddc5e9d770f7bf3169/items.c#L366), which calls [item_make_header](https://github.com/memcached/memcached/blob/4b23988acb2151de8009d0ddc5e9d770f7bf3169/items.c#L165).
Folsom tries to check if the value is too large before sending the request to memcached, but [it only takes the value size into account](https://github.com/spotify/folsom/blob/master/folsom/src/main/java/com/spotify/folsom/client/DefaultRawMemcacheClient.java#L224-L231). It should instead take the whole [request](https://github.com/spotify/folsom/blob/master/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java#L99-L117) into account, to be consistent with the memcached.
Sending these requests that are bound to fail to memcached badly affects performance since they end the connection to memcached.

This PR fixes this issue by doing the correct validation (against request size not value size) before sending the request.
