### PR TITLE
Add support for authenticated ASCII protocol

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -26,11 +26,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.spotify.dns.DnsSrvResolver;
 import com.spotify.folsom.authenticate.AsciiAuthenticationValidator;
+import com.spotify.folsom.authenticate.AsciiAuthenticator;
 import com.spotify.folsom.authenticate.Authenticator;
 import com.spotify.folsom.authenticate.BinaryAuthenticationValidator;
 import com.spotify.folsom.authenticate.MultiAuthenticator;
 import com.spotify.folsom.authenticate.NoAuthenticationValidation;
 import com.spotify.folsom.authenticate.PlaintextAuthenticator;
+import com.spotify.folsom.authenticate.UsernamePasswordPair;
 import com.spotify.folsom.client.NoopMetrics;
 import com.spotify.folsom.client.NoopTracer;
 import com.spotify.folsom.client.ascii.DefaultAsciiMemcacheClient;
@@ -58,6 +60,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class MemcacheClientBuilder<V> {
 
@@ -115,7 +118,7 @@ public class MemcacheClientBuilder<V> {
   private EventLoopGroup eventLoopGroup;
   private Class<? extends Channel> channelClass;
 
-  private final List<PlaintextAuthenticator> passwords = new ArrayList<>();
+  private final List<UsernamePasswordPair> passwords = new ArrayList<>();
   private boolean skipAuth = false;
 
   /**
@@ -538,7 +541,7 @@ public class MemcacheClientBuilder<V> {
    */
   public MemcacheClientBuilder<V> withUsernamePassword(
       final String username, final String password) {
-    passwords.add(new PlaintextAuthenticator(username, password));
+    passwords.add(new UsernamePasswordPair(username, password));
     return this;
   }
 
@@ -577,7 +580,16 @@ public class MemcacheClientBuilder<V> {
     if (passwords.isEmpty()) {
       return defaultValue;
     }
-    return new MultiAuthenticator(passwords);
+
+    if (defaultValue instanceof BinaryAuthenticationValidator) {
+      List<PlaintextAuthenticator> authenticatorList = passwords.stream().map(UsernamePasswordPair::getPlainTextAuthenticator).collect(Collectors.toList());
+      return new MultiAuthenticator(authenticatorList);
+    } else if (defaultValue instanceof AsciiAuthenticationValidator) {
+      List<AsciiAuthenticator> authenticatorList = passwords.stream().map(UsernamePasswordPair::getAsciiAuthenticator).collect(Collectors.toList());
+      return new MultiAuthenticator(authenticatorList);
+    }
+    throw new IllegalStateException(
+            "Only ASCII and binary protocols support authentication.");
   }
 
   /**

--- a/folsom/src/main/java/com/spotify/folsom/authenticate/AsciiAuthenticator.java
+++ b/folsom/src/main/java/com/spotify/folsom/authenticate/AsciiAuthenticator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.spotify.folsom.authenticate;
+
+import static com.spotify.folsom.client.Utils.unwrap;
+import static java.util.Objects.requireNonNull;
+
+import com.spotify.folsom.MemcacheAuthenticationException;
+import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.RawMemcacheClient;
+import com.spotify.folsom.client.ascii.AsciiAuthenticateRequest;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+
+public class AsciiAuthenticator implements Authenticator {
+
+  private final String username;
+  private final String password;
+
+  public AsciiAuthenticator(final String username, final String password) {
+    this.username = requireNonNull(username);
+    this.password = requireNonNull(password);
+  }
+
+  @Override
+  public CompletionStage<RawMemcacheClient> authenticate(RawMemcacheClient client) {
+
+    final AsciiAuthenticateRequest asciiAuthenticateRequest = new AsciiAuthenticateRequest(username, password);
+
+    return client
+        .connectFuture()
+        .thenCompose(
+            ignored ->
+                client
+                    .send(asciiAuthenticateRequest)
+                        .thenApply(
+                                status -> {
+                                  if (status == MemcacheStatus.OK) {
+                                    return client;
+                                  } else if (status == MemcacheStatus.UNAUTHORIZED) {
+                                    throw new MemcacheAuthenticationException("Authentication failed");
+                                  } else {
+                                    throw new RuntimeException("Unexpected status: " + status.name());
+                                  }
+                                }));
+  }
+
+  @Override
+  public void validate(final boolean binary) {
+    if (binary) {
+      throw new IllegalStateException("Programmer error: wrong validator used");
+    }
+  }
+}

--- a/folsom/src/main/java/com/spotify/folsom/authenticate/UsernamePasswordPair.java
+++ b/folsom/src/main/java/com/spotify/folsom/authenticate/UsernamePasswordPair.java
@@ -1,0 +1,21 @@
+package com.spotify.folsom.authenticate;
+
+import static java.util.Objects.requireNonNull;
+
+public class UsernamePasswordPair {
+    private final String username;
+    private final String password;
+
+    public UsernamePasswordPair(final String username, final String password) {
+        this.username = requireNonNull(username);
+        this.password = requireNonNull(password);
+    }
+
+    public AsciiAuthenticator getAsciiAuthenticator() {
+        return new AsciiAuthenticator(username, password);
+    }
+
+    public PlaintextAuthenticator getPlainTextAuthenticator() {
+        return new PlaintextAuthenticator(username, password);
+    }
+}

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/AsciiAuthenticateRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/AsciiAuthenticateRequest.java
@@ -1,0 +1,36 @@
+package com.spotify.folsom.client.ascii;
+
+import com.spotify.folsom.MemcacheStatus;
+import com.spotify.folsom.guava.HostAndPort;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static com.spotify.folsom.MemcacheStatus.UNAUTHORIZED;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+public class AsciiAuthenticateRequest extends SetRequest {
+
+    private static final byte[] KEY = "ASCII_AUTH".getBytes(StandardCharsets.US_ASCII);
+
+    public AsciiAuthenticateRequest(final String username, final String password) {
+        super(Operation.SET, KEY, (username + " " + password).getBytes(US_ASCII), 0, 0, 0 );
+    }
+
+    @Override
+    public void handle(AsciiResponse response, HostAndPort server) throws IOException {
+        switch (response.type) {
+            case STORED:
+                succeed(MemcacheStatus.OK);
+                return;
+            case CLIENT_ERROR:
+                succeed(UNAUTHORIZED);
+                return;
+            default:
+                final IOException exception =
+                        new IOException(
+                                String.format("Invalid response %s, expected STORED or CLIENT_ERROR.", response.type));
+                fail(exception, server);
+        }
+    }
+}

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/AsciiMemcacheDecoder.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/AsciiMemcacheDecoder.java
@@ -215,6 +215,10 @@ public class AsciiMemcacheDecoder extends ByteToMessageDecoder {
           expect(firstChar, "NOT_STORED");
           out.add(AsciiResponse.NOT_STORED);
           return;
+        } else if (tokenLength == 12) {
+          expect(firstChar, "CLIENT_ERROR");
+          out.add(AsciiResponse.CLIENT_ERROR);
+          return;
         } else {
           final String lineStr = toString(line);
           switch (lineStr) {

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/AsciiResponse.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/AsciiResponse.java
@@ -27,6 +27,7 @@ public class AsciiResponse {
   public static final AsciiResponse ERROR = new AsciiResponse(Type.ERROR);
   public static final AsciiResponse VALUE_TOO_LARGE = new AsciiResponse(Type.VALUE_TOO_LARGE);
   public static final AsciiResponse OUT_OF_MEMORY = new AsciiResponse(Type.OUT_OF_MEMORY);
+  public static final AsciiResponse CLIENT_ERROR = new AsciiResponse(Type.CLIENT_ERROR);
 
   public final Type type;
 
@@ -48,6 +49,7 @@ public class AsciiResponse {
     EMPTY_LIST,
     ERROR,
     VALUE_TOO_LARGE,
-    OUT_OF_MEMORY
+    OUT_OF_MEMORY,
+    CLIENT_ERROR
   }
 }

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
@@ -51,7 +51,7 @@ public class SetRequest extends AsciiRequest<MemcacheStatus>
   private final long cas;
   private final int flags;
 
-  private SetRequest(
+  SetRequest(
       final Operation operation,
       final byte[] key,
       final byte[] value,

--- a/folsom/src/test/java/com/spotify/folsom/KetamaServers.java
+++ b/folsom/src/test/java/com/spotify/folsom/KetamaServers.java
@@ -21,7 +21,7 @@ public class KetamaServers {
 
   public void setup() {
     for (MemcachedServer server : servers) {
-      server.start();
+      server.start(MemcachedServer.AuthenticationMode.NONE);
     }
   }
 

--- a/folsom/src/test/java/com/spotify/folsom/MemcachedServer.java
+++ b/folsom/src/test/java/com/spotify/folsom/MemcachedServer.java
@@ -16,6 +16,11 @@
 package com.spotify.folsom;
 
 import com.google.common.base.Suppliers;
+
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.images.builder.Transferable;
+
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -23,13 +28,22 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 
+
 public class MemcachedServer {
+
+  public enum AuthenticationMode {
+    NONE,
+    SASL,
+    ASCII
+  }
 
   private final FixedHostPortGenericContainer container;
   private MemcacheClient<String> client;
 
   public static final Supplier<MemcachedServer> SIMPLE_INSTANCE =
       Suppliers.memoize(MemcachedServer::new)::get;
+
+  public static int DEFAULT_PORT = 11211;
   private final String username;
   private final String password;
 
@@ -38,23 +52,38 @@ public class MemcachedServer {
   }
 
   public MemcachedServer(String username, String password) {
-    this(username, password, Optional.empty());
+    this(username, password, DEFAULT_PORT, AuthenticationMode.NONE);
   }
 
-  public MemcachedServer(String username, String password, Optional<Integer> fixedPort) {
+  public MemcachedServer(String username, String password, AuthenticationMode authenticationMode) {
+    this(username, password, DEFAULT_PORT, authenticationMode);
+  }
+
+  public MemcachedServer(String username, String password, int port, AuthenticationMode authenticationMode) {
     this.username = username;
     this.password = password;
-    container = new FixedHostPortGenericContainer("bitnami/memcached:1.5.12");
-    if (fixedPort.isPresent()) {
-      container.withFixedExposedPort(11211, fixedPort.get());
+    container = new FixedHostPortGenericContainer("bitnami/memcached:1.6.21");
+    if (port != DEFAULT_PORT) {
+      container.withFixedExposedPort(DEFAULT_PORT, port);
     } else {
-      container.withExposedPorts(11211);
+      container.withExposedPorts(DEFAULT_PORT);
     }
-    if (username != null && password != null) {
-      container.withEnv("MEMCACHED_USERNAME", username);
-      container.withEnv("MEMCACHED_PASSWORD", password);
+    switch (authenticationMode) {
+      case NONE:
+        break;
+      case SASL:
+        if (username != null && password != null) {
+          container.withEnv("MEMCACHED_USERNAME", username);
+          container.withEnv("MEMCACHED_PASSWORD", password);
+        }
+        break;
+      case ASCII:
+        container.withClasspathResourceMapping("/auth.file", "/tmp/auth.file", BindMode.READ_ONLY);
+        container.setCommand("/opt/bitnami/scripts/memcached/run.sh -vvvv -Y /tmp/auth.file");
+        break;
     }
-    start();
+
+    start(authenticationMode);
   }
 
   public void stop() {
@@ -68,7 +97,7 @@ public class MemcachedServer {
     container.stop();
   }
 
-  public void start() {
+  public void start(AuthenticationMode authenticationMode) {
     if (!container.isRunning()) {
       container.start();
     }
@@ -78,7 +107,16 @@ public class MemcachedServer {
       if (username != null && password != null) {
         builder.withUsernamePassword(username, password);
       }
-      client = builder.connectBinary();
+      switch (authenticationMode) {
+        case NONE:
+        case SASL:
+          client = builder.connectBinary();
+          break;
+        case ASCII:
+          client = builder.connectAscii();
+          break;
+      }
+
       try {
         client.awaitConnected(10, TimeUnit.SECONDS);
       } catch (InterruptedException | TimeoutException e) {
@@ -88,7 +126,7 @@ public class MemcachedServer {
   }
 
   public int getPort() {
-    return container.getMappedPort(11211);
+    return container.getMappedPort(DEFAULT_PORT);
   }
 
   public String getHost() {

--- a/folsom/src/test/java/com/spotify/folsom/authenticate/AsciiAuthenticatedMemcacheClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/authenticate/AsciiAuthenticatedMemcacheClientTest.java
@@ -15,83 +15,82 @@
  */
 package com.spotify.folsom.authenticate;
 
-import static com.spotify.folsom.MemcacheStatus.OK;
-import static com.spotify.hamcrest.future.CompletableFutureMatchers.stageWillCompleteWithValueThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import com.spotify.folsom.BinaryMemcacheClient;
 import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.MemcacheClient;
 import com.spotify.folsom.MemcacheClientBuilder;
 import com.spotify.folsom.MemcachedServer;
-
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class DefaultAuthenticatedMemcacheClientTest {
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.spotify.folsom.MemcacheStatus.OK;
+import static com.spotify.hamcrest.future.CompletableFutureMatchers.stageWillCompleteWithValueThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class AsciiAuthenticatedMemcacheClientTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String USERNAME = "theuser";
   private static final String PASSWORD = "a_nice_password";
   private static final String WRONG_PASSWORD = "wrong_password";
+  
 
-  private static MemcachedServer saslServer;
-  private static MemcachedServer noAuthServer;
-
+  private static MemcachedServer asciiAuthServer;
 
   @BeforeClass
   public static void setUpClass() {
-    noAuthServer = MemcachedServer.SIMPLE_INSTANCE.get();
-    saslServer = new MemcachedServer(USERNAME, PASSWORD, MemcachedServer.AuthenticationMode.SASL);
+    asciiAuthServer = new MemcachedServer(USERNAME, PASSWORD, MemcachedServer.AuthenticationMode.ASCII);
   }
 
   @AfterClass
   public static void tearDownClass() {
-    if (saslServer != null) {
-      saslServer.stop();
+    if (asciiAuthServer != null) {
+      asciiAuthServer.stop();
     }
   }
 
   @Test
   public void testAuthenticateAndSet() throws InterruptedException, TimeoutException {
-    testSaslAuthenticationSuccess(saslServer);
+    testAsciiAuthenticationSuccess(asciiAuthServer);
   }
+  
 
-  @Test
-  public void testAuthenticateNoSASLServer() throws InterruptedException, TimeoutException {
-    testSaslAuthenticationSuccess(noAuthServer);
-  }
-
-  private void testSaslAuthenticationSuccess(final MemcachedServer server)
+  private void testAsciiAuthenticationSuccess(final MemcachedServer server)
       throws TimeoutException, InterruptedException {
     MemcacheClient<String> client =
         MemcacheClientBuilder.newStringClient()
             .withAddress(server.getHost(), server.getPort())
             .withUsernamePassword(USERNAME, WRONG_PASSWORD)
             .withUsernamePassword(USERNAME, PASSWORD)
-            .connectBinary();
+            .connectAscii();
 
     client.awaitConnected(20, TimeUnit.SECONDS);
 
     assertThat(
         client.set("some_key", "some_val", 1).toCompletableFuture(),
         stageWillCompleteWithValueThat(is(OK)));
+
+    assertThat(
+            client.get("some_key").toCompletableFuture(),
+            stageWillCompleteWithValueThat(is("some_val")));
   }
 
   @Test
   public void testFailedAuthentication() throws InterruptedException, TimeoutException {
     MemcacheClient<String> client =
         MemcacheClientBuilder.newStringClient()
-            .withAddress(saslServer.getHost(), saslServer.getPort())
+            .withAddress(asciiAuthServer.getHost(), asciiAuthServer.getPort())
             .withUsernamePassword(USERNAME, WRONG_PASSWORD)
             .withUsernamePassword(USERNAME, WRONG_PASSWORD)
-            .connectBinary();
+            .connectAscii();
 
     thrown.expect(MemcacheAuthenticationException.class);
     client.awaitConnected(20, TimeUnit.SECONDS);
@@ -101,50 +100,23 @@ public class DefaultAuthenticatedMemcacheClientTest {
   public void unAuthorizedBinaryClientFails() throws InterruptedException, TimeoutException {
     MemcacheClient<String> client =
         MemcacheClientBuilder.newStringClient()
-            .withAddress(saslServer.getHost(), saslServer.getPort())
+            .withAddress(asciiAuthServer.getHost(), asciiAuthServer.getPort())
+            .withUsernamePassword(USERNAME, WRONG_PASSWORD)
             .connectBinary();
 
-    thrown.expect(MemcacheAuthenticationException.class);
-    client.awaitConnected(20, TimeUnit.SECONDS);
+
+    thrown.expect(TimeoutException.class);
+    client.awaitConnected(2, TimeUnit.SECONDS);
   }
 
   @Test
   public void unAuthorizedAsciiClientFails() throws InterruptedException, TimeoutException {
     MemcacheClient<String> client =
         MemcacheClientBuilder.newStringClient()
-            .withAddress(saslServer.getHost(), saslServer.getPort())
+            .withAddress(asciiAuthServer.getHost(), asciiAuthServer.getPort())
             .connectAscii();
 
     thrown.expect(TimeoutException.class);
-    client.awaitConnected(1, TimeUnit.SECONDS);
-  }
-
-  @Test
-  public void testKetamaFailure() throws InterruptedException, TimeoutException {
-    BinaryMemcacheClient<String> client =
-        MemcacheClientBuilder.newStringClient()
-            .withAddress(saslServer.getHost(), saslServer.getPort())
-            .withAddress(noAuthServer.getHost(), noAuthServer.getPort())
-            .connectBinary();
-
-    thrown.expect(MemcacheAuthenticationException.class);
-    client.awaitFullyConnected(10, TimeUnit.SECONDS);
-  }
-
-  @Test
-  public void testKetamaSuccess() throws TimeoutException, InterruptedException {
-    BinaryMemcacheClient<String> client =
-        MemcacheClientBuilder.newStringClient()
-            .withAddress(saslServer.getHost(), saslServer.getPort())
-            .withAddress(noAuthServer.getHost(), noAuthServer.getPort())
-            .withUsernamePassword(USERNAME, WRONG_PASSWORD)
-            .withUsernamePassword(USERNAME, PASSWORD)
-            .connectBinary();
-
-    client.awaitConnected(20, TimeUnit.SECONDS);
-
-    assertThat(
-        client.set("some_key", "some_val", 1).toCompletableFuture(),
-        stageWillCompleteWithValueThat(is(OK)));
+    client.awaitConnected(2, TimeUnit.SECONDS);
   }
 }

--- a/folsom/src/test/resources/auth.file
+++ b/folsom/src/test/resources/auth.file
@@ -1,0 +1,1 @@
+theuser:a_nice_password


### PR DESCRIPTION
This PR introduces support for the ASCII protocol authentication, as described in the [protocol.txt](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L186) definition as below:

```
Optional username/password token authentication (see -Y option). Used by
sending a fake "set" command with any key:

set <key> <flags> <exptime> <bytes>\r\n
username password\r\n

key, flags, and exptime are ignored for authentication. Bytes is the length
of the username/password payload.

- "STORED\r\n" indicates success. After this point any command should work
  normally.

- "CLIENT_ERROR [message]\r\n" will be returned if authentication fails for
  any reason.
```
