### PR TITLE
Add unauthenticated errors for ASCII protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.16.1
+* Add non-authenticated errors for all ASCII operations
+
 ### 1.16.0
 * Add support for ASCII authentication
 

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/DeleteRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/DeleteRequest.java
@@ -16,6 +16,7 @@
 
 package com.spotify.folsom.client.ascii;
 
+import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.Request;
 import com.spotify.folsom.guava.HostAndPort;
@@ -54,6 +55,12 @@ public class DeleteRequest extends AsciiRequest<MemcacheStatus> {
         return;
       case NOT_FOUND:
         succeed(MemcacheStatus.KEY_NOT_FOUND);
+        return;
+      case CLIENT_ERROR:
+        MemcacheAuthenticationException exception =
+            new MemcacheAuthenticationException(
+                "Authentication required by server. Client not authenticated.");
+        fail(exception, server);
         return;
       default:
         throw new IOException("Unexpected response type: " + response.type);

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/DeleteWithCasRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/DeleteWithCasRequest.java
@@ -18,6 +18,7 @@ package com.spotify.folsom.client.ascii;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.Request;
 import com.spotify.folsom.guava.HostAndPort;
@@ -72,6 +73,12 @@ public class DeleteWithCasRequest extends AsciiRequest<MemcacheStatus> {
         return;
       case NOT_FOUND:
         succeed(MemcacheStatus.KEY_NOT_FOUND);
+        return;
+      case CLIENT_ERROR:
+        MemcacheAuthenticationException exception =
+            new MemcacheAuthenticationException(
+                "Authentication required by server. Client not authenticated.");
+        fail(exception, server);
         return;
       default:
         throw new IOException("Unexpected line: " + response.type);

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/FlushRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/FlushRequest.java
@@ -15,6 +15,7 @@
  */
 package com.spotify.folsom.client.ascii;
 
+import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.AllRequest;
 import com.spotify.folsom.client.Request;
@@ -51,6 +52,11 @@ public class FlushRequest extends AsciiRequest<MemcacheStatus>
     AsciiResponse.Type type = response.type;
     if (type == AsciiResponse.Type.OK) {
       succeed(MemcacheStatus.OK);
+    } else if (type == AsciiResponse.Type.CLIENT_ERROR) {
+      MemcacheAuthenticationException exception =
+          new MemcacheAuthenticationException(
+              "Authentication required by server. Client not authenticated.");
+      fail(exception, server);
     } else {
       throw new IOException("Unexpected line: " + type);
     }

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/GetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/GetRequest.java
@@ -66,6 +66,7 @@ public class GetRequest extends AsciiRequest<GetResult<byte[]>>
           new MemcacheAuthenticationException(
               "Authentication required by server. Client not authenticated.");
       fail(exception, server);
+      return;
     }
 
     if (!(response instanceof ValueAsciiResponse)) {

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/IncrRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/IncrRequest.java
@@ -16,6 +16,7 @@
 
 package com.spotify.folsom.client.ascii;
 
+import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.ascii.AsciiResponse.Type;
 import com.spotify.folsom.guava.HostAndPort;
@@ -69,6 +70,11 @@ public class IncrRequest extends AsciiRequest<Long> {
       succeed(((NumericAsciiResponse) response).numericValue);
     } else if (response.type == Type.NOT_FOUND) {
       succeed(null);
+    } else if (response.type == AsciiResponse.Type.CLIENT_ERROR) {
+      MemcacheAuthenticationException exception =
+          new MemcacheAuthenticationException(
+              "Authentication required by server. Client not authenticated.");
+      fail(exception, server);
     } else {
       throw new IOException("Unexpected response type: " + response.type);
     }

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/MultigetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/MultigetRequest.java
@@ -17,6 +17,7 @@
 package com.spotify.folsom.client.ascii;
 
 import com.spotify.folsom.GetResult;
+import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.client.MemcacheEncoder;
 import com.spotify.folsom.client.MultiRequest;
 import com.spotify.folsom.client.Request;
@@ -81,6 +82,14 @@ public class MultigetRequest extends AsciiRequest<List<GetResult<byte[]>>>
 
     if (response.type == AsciiResponse.Type.EMPTY_LIST) {
       succeed(result);
+      return;
+    }
+
+    if (response.type == AsciiResponse.Type.CLIENT_ERROR) {
+      MemcacheAuthenticationException exception =
+          new MemcacheAuthenticationException(
+              "Authentication required by server. Client not authenticated.");
+      fail(exception, server);
       return;
     }
 

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/SetRequest.java
@@ -18,6 +18,7 @@ package com.spotify.folsom.client.ascii;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
+import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.OpCode;
 import com.spotify.folsom.client.Request;
@@ -164,6 +165,12 @@ public class SetRequest extends AsciiRequest<MemcacheStatus>
         } else {
           succeed(MemcacheStatus.KEY_NOT_FOUND);
         }
+        return;
+      case CLIENT_ERROR:
+        MemcacheAuthenticationException exception =
+            new MemcacheAuthenticationException(
+                "Authentication required by server. Client not authenticated.");
+        fail(exception, server);
         return;
       default:
         throw new IOException("Unexpected line: " + response.type);

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/StatsRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/StatsRequest.java
@@ -16,6 +16,7 @@
 package com.spotify.folsom.client.ascii;
 
 import com.google.common.collect.ImmutableMap;
+import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.MemcachedStats;
 import com.spotify.folsom.client.AllRequest;
 import com.spotify.folsom.client.Request;
@@ -58,6 +59,11 @@ public class StatsRequest extends AsciiRequest<Map<String, MemcachedStats>>
       succeed(ImmutableMap.of(host, new MemcachedStats(statsResponse.values)));
     } else if (type == AsciiResponse.Type.ERROR) {
       succeed(ImmutableMap.of(host, new MemcachedStats(ImmutableMap.of())));
+    } else if (type == AsciiResponse.Type.CLIENT_ERROR) {
+      MemcacheAuthenticationException exception =
+          new MemcacheAuthenticationException(
+              "Authentication required by server. Client not authenticated.");
+      fail(exception, server);
     } else {
       throw new IOException("Unexpected response type: " + type);
     }

--- a/folsom/src/main/java/com/spotify/folsom/client/ascii/TouchRequest.java
+++ b/folsom/src/main/java/com/spotify/folsom/client/ascii/TouchRequest.java
@@ -15,6 +15,7 @@
  */
 package com.spotify.folsom.client.ascii;
 
+import com.spotify.folsom.MemcacheAuthenticationException;
 import com.spotify.folsom.MemcacheStatus;
 import com.spotify.folsom.client.Request;
 import com.spotify.folsom.client.Utils;
@@ -56,6 +57,11 @@ public class TouchRequest extends AsciiRequest<MemcacheStatus> {
       succeed(MemcacheStatus.OK);
     } else if (type == AsciiResponse.Type.NOT_FOUND) {
       succeed(MemcacheStatus.KEY_NOT_FOUND);
+    } else if (type == AsciiResponse.Type.CLIENT_ERROR) {
+      MemcacheAuthenticationException exception =
+          new MemcacheAuthenticationException(
+              "Authentication required by server. Client not authenticated.");
+      fail(exception, server);
     } else {
       throw new IOException("Unexpected line: " + type);
     }

--- a/folsom/src/test/java/com/spotify/folsom/authenticate/BinaryAuthenticatedMemcacheClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/authenticate/BinaryAuthenticatedMemcacheClientTest.java
@@ -33,7 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class DefaultAuthenticatedMemcacheClientTest {
+public class BinaryAuthenticatedMemcacheClientTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final String USERNAME = "theuser";


### PR DESCRIPTION
This PR adds exception handling to when a client instance tries to send commands to an unauthenticated connection to a server that requires authentication.