### PR TITLE
feat: introduce a ReconnectionListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+* feat: introduce a `ReconnectionListener` which the `ReconnectingClient` will call when trying to reconnect. This is
+  called more often than registered `ConnectionChangeListener`s, and is mostly useful for logging purposes.
+
 ### 1.16.1
 * Add non-authenticated errors for all ASCII operations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Unreleased
+### 1.17.0
 * feat: introduce a `ReconnectionListener` which the `ReconnectingClient` will call when trying to reconnect. This is
   called more often than registered `ConnectionChangeListener`s, and is mostly useful for logging purposes.
 

--- a/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
+++ b/folsom/src/main/java/com/spotify/folsom/MemcacheClientBuilder.java
@@ -41,6 +41,7 @@ import com.spotify.folsom.guava.HostAndPort;
 import com.spotify.folsom.ketama.AddressAndClient;
 import com.spotify.folsom.ketama.KetamaMemcacheClient;
 import com.spotify.folsom.ketama.ResolvingKetamaClient;
+import com.spotify.folsom.reconnect.CatchingReconnectionListener;
 import com.spotify.folsom.reconnect.ReconnectingClient;
 import com.spotify.folsom.reconnect.ReconnectionListener;
 import com.spotify.folsom.retry.RetryingClient;
@@ -316,13 +317,16 @@ public class MemcacheClientBuilder<V> {
    * implementation} whatsoever, meaning you would need to either delegate to it, or reimplement its
    * behaviour.
    *
+   * <p>This method will implicitly wrap your listener in a {@link CatchingReconnectionListener}.
+   * This is to ensure they cannot break the client returned if they throw.
+   *
    * @param reconnectionListener the listener for reconnections
    * @return itself
    */
   public MemcacheClientBuilder<V> withReconnectionListener(
       final ReconnectionListener reconnectionListener) {
-    this.reconnectionListener =
-        requireNonNull(reconnectionListener, "reconnectionListener cannot be null");
+    requireNonNull(reconnectionListener, "reconnectionListener cannot be null");
+    this.reconnectionListener = new CatchingReconnectionListener(reconnectionListener);
     return this;
   }
 

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/AbstractReconnectionListener.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/AbstractReconnectionListener.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.folsom.reconnect;
+
+import com.spotify.folsom.guava.HostAndPort;
+import javax.annotation.Nullable;
+
+/**
+ * A listener for each reconnection event. This will be called more often than the {@link
+ * com.spotify.folsom.ConnectionChangeListener ConnectionChangeListener}s. For more information on
+ * this, see {@link ReconnectionListener}.
+ *
+ * <p>This class acts as a stable interface for {@link ReconnectionListener}. While {@link
+ * ReconnectionListener} can have source-incompatible changes in minor versions, this cannot do
+ * that.
+ *
+ * @see ReconnectionListener
+ */
+public abstract class AbstractReconnectionListener implements ReconnectionListener {
+  /** {@inheritDoc} */
+  @Override
+  public void connectionFailure(final Throwable cause) {
+    // No-op.
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectionLost(final @Nullable Throwable cause, final HostAndPort address) {
+    // No-op.
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void reconnectionSuccessful(
+      final HostAndPort address, final int attempt, final boolean willStayConnected) {
+    // No-op.
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void reconnectionCancelled() {
+    // No-op.
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void reconnectionQueuedFromError(
+      final Throwable cause,
+      final HostAndPort address,
+      final long backOffMillis,
+      final int attempt) {
+    // No-op.
+  }
+}

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/CatchingReconnectionListener.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/CatchingReconnectionListener.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.folsom.reconnect;
+
+import com.spotify.folsom.guava.HostAndPort;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link ReconnectionListener} which ensures the methods never throw {@link Exception} (though
+ * {@link Error} and {@link Throwable} are not caught).
+ *
+ * <p>This should wrap any untrusted {@link ReconnectionListener}.
+ *
+ * <p>This class should be regarded as <b>internal API</b>. We recognise it may be useful outside
+ * internals, to which end it is exposed. The constructor is <b>stable</b>. All methods are
+ * <b>unstable</b> and can change with breakage in patch versions. If you want a stable interface,
+ * wrap your own reconnection listener in this, instead of extending it (and instead extend {@link
+ * AbstractReconnectionListener}).
+ */
+public class CatchingReconnectionListener implements ReconnectionListener {
+
+  private static final Logger log = LoggerFactory.getLogger(CatchingReconnectionListener.class);
+
+  private final ReconnectionListener delegate;
+
+  public CatchingReconnectionListener(final ReconnectionListener delegate) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectionFailure(final Throwable cause) {
+    try {
+      delegate.connectionFailure(cause);
+    } catch (final Exception ex) {
+      log.warn("Delegate ReconnectionListener threw on #connectionFailure: {}", this.delegate, ex);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void reconnectionCancelled() {
+    try {
+      delegate.reconnectionCancelled();
+    } catch (final Exception ex) {
+      log.warn(
+          "Delegate ReconnectionListener threw on #reconnectionCancelled: {}", this.delegate, ex);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void reconnectionSuccessful(
+      final HostAndPort address, final int attempt, final boolean willStayConnected) {
+    try {
+      delegate.reconnectionSuccessful(address, attempt, willStayConnected);
+    } catch (final Exception ex) {
+      log.warn(
+          "Delegate ReconnectionListener threw on #reconnectionSuccessful: {}", this.delegate, ex);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void connectionLost(final @Nullable Throwable cause, final HostAndPort address) {
+    try {
+      delegate.connectionLost(cause, address);
+    } catch (final Exception ex) {
+      log.warn("Delegate ReconnectionListener threw on #connectionLost: {}", this.delegate, ex);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void reconnectionQueuedFromError(
+      final Throwable cause,
+      final HostAndPort address,
+      final long backOffMillis,
+      final int attempt) {
+    try {
+      delegate.reconnectionQueuedFromError(cause, address, backOffMillis, attempt);
+    } catch (final Exception ex) {
+      log.warn(
+          "Delegate ReconnectionListener threw on #reconnectionQueuedFromError: {}",
+          this.delegate,
+          ex);
+    }
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CatchingReconnectionListener)) {
+      return false;
+    }
+    final CatchingReconnectionListener that = (CatchingReconnectionListener) o;
+    return this.delegate.equals(that.delegate);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.delegate);
+  }
+
+  @Override
+  public String toString() {
+    return "CatchingReconnectionListener{delegate=" + this.delegate + '}';
+  }
+}

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -160,7 +160,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     this.backoffFunction = backoffFunction;
     this.scheduledExecutorService = scheduledExecutorService;
     this.connector = connector;
-    this.reconnectionListener = new CatchingReconnectionListener(reconnectionListener);
+    this.reconnectionListener = reconnectionListener;
 
     this.address = address;
     retry();

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectionListener.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectionListener.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.folsom.reconnect;
+
+import com.spotify.folsom.guava.HostAndPort;
+import javax.annotation.Nullable;
+
+/**
+ * A listener for each reconnection event. This will be called more often than the {@link
+ * com.spotify.folsom.ConnectionChangeListener ConnectionChangeListener}s.
+ *
+ * <p>If you implement this interface manually, expect there to be changes in <b>minor versions</b>
+ * which can cause source-incompatibility. If you want to implement this interface without this
+ * hassle, extend {@link AbstractReconnectionListener} instead.
+ */
+public interface ReconnectionListener {
+
+  /**
+   * A connection to Memcached was attempted, but ultimately failed.
+   *
+   * @param cause why the connection failed, never {@code null}
+   */
+  void connectionFailure(final Throwable cause);
+
+  /**
+   * The reconnection was cancelled. This can be because the client was shut down between the
+   * connection and clean up upon a retry, or because a connection couldn't be acquired to begin
+   * with.
+   */
+  void reconnectionCancelled();
+
+  /**
+   * A reconnect was successful, and a new connection has been set up.
+   *
+   * @param address the address to which the client connected, never {@code null}
+   * @param attempt which attempt it succeeded on; this is 1-indexed (i.e. 1st attempt is 1, 2nd is
+   *     2)
+   * @param willStayConnected whether the connection will immediately close after this, often due to
+   *     race conditions
+   */
+  void reconnectionSuccessful(
+      final HostAndPort address, final int attempt, final boolean willStayConnected);
+
+  /**
+   * A connection to Memcached was lost after having been acquired.
+   *
+   * <p>This will be called regardless of if it was shut down intentionally, or in error.
+   *
+   * @param cause the cause of losing the connection, can be {@code null}
+   * @param address the address to the Memcached node we were connected, never {@code null}
+   */
+  void connectionLost(final @Nullable Throwable cause, final HostAndPort address);
+
+  /**
+   * A new reconnection has been queued on the executor. This is done after a failure occurred.
+   *
+   * <p>If the client is shut down between this call and the actual connection, you will never see a
+   * follow-up to any success or failure method.
+   *
+   * @param cause the cause of the reconnection, i.e. "what failed to cause this?", never {@code
+   *     null}
+   * @param address the address to the Memcached node we will connect to, never {@code null}
+   * @param backOffMillis how many milliseconds we will wait before we attempt again, never {@code
+   *     null}
+   * @param attempt which attempt we are on; this is 1-indexed (i.e. 1st attempt is 1, 2nd is 2)
+   */
+  void reconnectionQueuedFromError(
+      final Throwable cause,
+      final HostAndPort address,
+      final long backOffMillis,
+      final int attempt);
+}

--- a/folsom/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Spotify AB
+ * Copyright (c) 2015-2023 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/folsom/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/MisbehavingServerTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
@@ -213,7 +214,7 @@ public class MisbehavingServerTest {
     server = new Server(response);
     MemcacheClient<String> client =
         MemcacheClientBuilder.newStringClient()
-            .withAddress("127.0.0.8", server.port)
+            .withAddress(server.inetAddress.getHostAddress(), server.port)
             .withRequestTimeoutMillis(100L)
             .withRetry(false)
             .connectAscii();
@@ -222,6 +223,7 @@ public class MisbehavingServerTest {
   }
 
   private static class Server {
+    private final InetAddress inetAddress;
     private final int port;
     private final ServerSocket serverSocket;
     private final Thread thread;
@@ -232,6 +234,7 @@ public class MisbehavingServerTest {
     private Server(String responseString) throws IOException {
       final byte[] response = responseString.getBytes(StandardCharsets.UTF_8);
       serverSocket = new ServerSocket(0);
+      inetAddress = serverSocket.getInetAddress();
       port = serverSocket.getLocalPort();
       thread =
           new Thread(

--- a/folsom/src/test/java/com/spotify/folsom/reconnect/ReconnectingClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/reconnect/ReconnectingClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015 Spotify AB
+ * Copyright (c) 2014-2023 Spotify AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -86,7 +86,8 @@ public class ReconnectingClientTest {
             backoffFunction,
             scheduledExecutorService,
             connector,
-            HostAndPort.fromString("localhost:123"));
+            HostAndPort.fromString("localhost:123"),
+            new ReconnectingClient.StandardReconnectionListener());
 
     verify(connector, times(3)).connect();
     verify(scheduledExecutorService, times(1))
@@ -122,7 +123,8 @@ public class ReconnectingClientTest {
             backoffFunction,
             scheduledExecutorService,
             connector,
-            HostAndPort.fromString("localhost:123"));
+            HostAndPort.fromString("localhost:123"),
+            new ReconnectingClient.StandardReconnectionListener());
 
     verify(connector, times(4)).connect();
     verify(scheduledExecutorService, times(1))
@@ -153,7 +155,8 @@ public class ReconnectingClientTest {
             backoffFunction,
             scheduledExecutorService,
             connector,
-            HostAndPort.fromString("localhost:123"));
+            HostAndPort.fromString("localhost:123"),
+            new ReconnectingClient.StandardReconnectionListener());
 
     assertTrue(client.isConnected());
     client.shutdown();

--- a/folsom/src/test/java/com/spotify/folsom/reconnect/ReconnectionListenerTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/reconnect/ReconnectionListenerTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.spotify.folsom.reconnect;
+
+import org.junit.Test;
+
+public class ReconnectionListenerTest {
+  @Test
+  public void ensureEmptyClassCompiles() {
+    // This class acts as a test. Nothing should be necessary from the abstract class, as such this
+    // one line of code should compile at all times.
+    //
+    // Needing to change this line should result in a minor version update, at least.
+    @SuppressWarnings("unused")
+    class EmptyReconnectionListener extends AbstractReconnectionListener {}
+  }
+}


### PR DESCRIPTION
This introduces a new `ReconnectionListener` interface, to allow for interfacing
with the `ReconnectingClient`. Its purpose is to act as a fly on the wall for
what happens in the `ReconnectingClient`, with no business logic influence, but
has the ability to open for Prometheus metrics, extra logging, Sentry tracing,
and the likes.

On a semi-related note, I've also changed the `MisbehavingServerTest` to not
use `127.0.0.8`, because this seemingly is not mapped to loopback on macOS (M1)
by default. Using the `InetAddress` of `ServerSocket#getInetAddress` should be
stable on all platforms, as far as I know.

Copyright notice: this was written and created at work, so it is owned in its
entirety by Spotify AB.