### PR TITLE
expanding Connector to include address information

### DIFF
--- a/folsom/src/main/java/com/spotify/folsom/authenticate/AuthenticatingClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/authenticate/AuthenticatingClient.java
@@ -17,15 +17,24 @@
 package com.spotify.folsom.authenticate;
 
 import com.spotify.folsom.RawMemcacheClient;
+import com.spotify.folsom.guava.HostAndPort;
 import com.spotify.folsom.reconnect.Connector;
 import java.util.concurrent.CompletionStage;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class AuthenticatingClient {
 
-  public static CompletionStage<RawMemcacheClient> authenticate(
+  public static CompletionStage<Pair<RawMemcacheClient, HostAndPort>> authenticate(
       Connector connector, final Authenticator authenticator) {
 
-    CompletionStage<RawMemcacheClient> client = connector.connect();
-    return client.thenCompose(authenticator::authenticate);
+    return connector.connect()
+        .thenCompose(p -> {
+
+          RawMemcacheClient client = p.getLeft();
+          HostAndPort host = p.getRight();
+
+          return authenticator.authenticate(client)
+              .thenApply(authenticatedClient -> Pair.of(authenticatedClient, host));
+        });
   }
 }

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/Connector.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/Connector.java
@@ -18,13 +18,12 @@ package com.spotify.folsom.reconnect;
 import com.spotify.folsom.RawMemcacheClient;
 import com.spotify.folsom.guava.HostAndPort;
 import java.util.concurrent.CompletionStage;
+import org.apache.commons.lang3.tuple.Pair;
 
 public interface Connector {
 
-  CompletionStage<RawMemcacheClient> connect();
-
   /**
-   * The host and port of RawMemcacheClient returned via connect(), if successful
+   * @return A memcached client along with its host and port information
    */
-  HostAndPort currentAddress();
+  CompletionStage<Pair<RawMemcacheClient, HostAndPort>> connect();
 }

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/Connector.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/Connector.java
@@ -16,8 +16,15 @@
 package com.spotify.folsom.reconnect;
 
 import com.spotify.folsom.RawMemcacheClient;
+import com.spotify.folsom.guava.HostAndPort;
 import java.util.concurrent.CompletionStage;
 
 public interface Connector {
+
   CompletionStage<RawMemcacheClient> connect();
+
+  /**
+   * The host and port of RawMemcacheClient returned via connect(), if successful
+   */
+  HostAndPort currentAddress();
 }

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -55,7 +55,6 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
   private final BackoffFunction backoffFunction;
   private final ScheduledExecutorService scheduledExecutorService;
   private final com.spotify.folsom.reconnect.Connector connector;
-  private final HostAndPort address;
   private final ReconnectionListener reconnectionListener;
 
   private volatile RawMemcacheClient client = NotConnectedClient.INSTANCE;
@@ -83,22 +82,30 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     this(
         backoffFunction,
         scheduledExecutorService,
-        () ->
-            DefaultRawMemcacheClient.connect(
-                address,
-                outstandingRequestLimit,
-                eventLoopThreadFlushMaxBatchSize,
-                binary,
-                executor,
-                connectionTimeoutMillis,
-                charset,
-                metrics,
-                maxSetLength,
-                eventLoopGroup,
-                channelClass,
-                sslEngineFactory),
+        new Connector() {
+          @Override
+          public CompletionStage<RawMemcacheClient> connect() {
+            return DefaultRawMemcacheClient.connect(
+              address,
+              outstandingRequestLimit,
+              eventLoopThreadFlushMaxBatchSize,
+              binary,
+              executor,
+              connectionTimeoutMillis,
+              charset,
+              metrics,
+              maxSetLength,
+              eventLoopGroup,
+              channelClass,
+              sslEngineFactory);
+          }
+
+          @Override
+          public HostAndPort currentAddress() {
+            return address;
+          }
+        },
         authenticator,
-        address,
         reconnectionListener);
   }
 
@@ -121,8 +128,10 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     this(
         backoffFunction,
         scheduledExecutorService,
-        () ->
-            DefaultRawMemcacheClient.connect(
+        new Connector() {
+          @Override
+          public CompletionStage<RawMemcacheClient> connect() {
+            return DefaultRawMemcacheClient.connect(
                 address,
                 outstandingRequestLimit,
                 eventLoopThreadFlushMaxBatchSize,
@@ -134,24 +143,38 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
                 maxSetLength,
                 eventLoopGroup,
                 channelClass,
-                sslEngineFactory),
+                sslEngineFactory);
+          }
+
+          @Override
+          public HostAndPort currentAddress() {
+            return address;
+          }
+        },
         authenticator,
-        address,
         new StandardReconnectionListener());
   }
 
-  private ReconnectingClient(
+  public ReconnectingClient(
       final BackoffFunction backoffFunction,
       final ScheduledExecutorService scheduledExecutorService,
       final Connector connector,
       final Authenticator authenticator,
-      final HostAndPort address,
       final ReconnectionListener reconnectionListener) {
     this(
         backoffFunction,
         scheduledExecutorService,
-        () -> AuthenticatingClient.authenticate(connector, authenticator),
-        address,
+        new Connector() {
+          @Override
+          public CompletionStage<RawMemcacheClient> connect() {
+            return AuthenticatingClient.authenticate(connector, authenticator);
+          }
+
+          @Override
+          public HostAndPort currentAddress() {
+            return connector.currentAddress();
+          }
+        },
         reconnectionListener);
   }
 
@@ -159,7 +182,6 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
       final BackoffFunction backoffFunction,
       final ScheduledExecutorService scheduledExecutorService,
       final com.spotify.folsom.reconnect.Connector connector,
-      final HostAndPort address,
       final ReconnectionListener reconnectionListener) {
     super();
     this.backoffFunction = backoffFunction;
@@ -167,7 +189,6 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     this.connector = connector;
     this.reconnectionListener = reconnectionListener;
 
-    this.address = address;
     retry();
   }
 
@@ -229,7 +250,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
               }
               ReconnectingClient.this.onFailure(t);
             } else {
-              reconnectionListener.reconnectionSuccessful(address, reconnectCount, stayConnected);
+              reconnectionListener.reconnectionSuccessful(connector.currentAddress(), reconnectCount, stayConnected);
               reconnectCount = 0;
               client.shutdown();
               client = newClient;
@@ -247,7 +268,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
                   .disconnectFuture()
                   .whenComplete(
                       (unused, throwable) ->
-                          reconnectionListener.connectionLost(throwable, address))
+                          reconnectionListener.connectionLost(throwable, connector.currentAddress()))
                   .thenRun(
                       () -> {
                         notifyConnectionChange();
@@ -271,7 +292,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     final long backOff = backoffFunction.getBackoffTimeMillis(reconnectCount);
 
     reconnectCount++;
-    this.reconnectionListener.reconnectionQueuedFromError(cause, address, backOff, reconnectCount);
+    this.reconnectionListener.reconnectionQueuedFromError(cause, connector.currentAddress(), backOff, reconnectCount);
 
     scheduledExecutorService.schedule(
         () -> {

--- a/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
+++ b/folsom/src/main/java/com/spotify/folsom/reconnect/ReconnectingClient.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +58,17 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
   private final com.spotify.folsom.reconnect.Connector connector;
   private final ReconnectionListener reconnectionListener;
 
-  private volatile RawMemcacheClient client = NotConnectedClient.INSTANCE;
+  private static final class ClientState {
+    final RawMemcacheClient client;
+    @Nullable final HostAndPort hostAndPort;
+
+    ClientState(RawMemcacheClient client, @Nullable HostAndPort hostAndPort) {
+      this.client = client;
+      this.hostAndPort = hostAndPort;
+    }
+  }
+
+  private volatile ClientState clientState = new ClientState(NotConnectedClient.INSTANCE, null);
   private volatile int reconnectCount = 0;
   private volatile boolean stayConnected = true;
   private volatile Throwable connectionFailure;
@@ -82,29 +93,20 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     this(
         backoffFunction,
         scheduledExecutorService,
-        new Connector() {
-          @Override
-          public CompletionStage<RawMemcacheClient> connect() {
-            return DefaultRawMemcacheClient.connect(
-              address,
-              outstandingRequestLimit,
-              eventLoopThreadFlushMaxBatchSize,
-              binary,
-              executor,
-              connectionTimeoutMillis,
-              charset,
-              metrics,
-              maxSetLength,
-              eventLoopGroup,
-              channelClass,
-              sslEngineFactory);
-          }
-
-          @Override
-          public HostAndPort currentAddress() {
-            return address;
-          }
-        },
+        () -> DefaultRawMemcacheClient.connect(
+                address,
+                outstandingRequestLimit,
+                eventLoopThreadFlushMaxBatchSize,
+                binary,
+                executor,
+                connectionTimeoutMillis,
+                charset,
+                metrics,
+                maxSetLength,
+                eventLoopGroup,
+                channelClass,
+                sslEngineFactory)
+            .thenApply(client -> Pair.of(client, address)),
         authenticator,
         reconnectionListener);
   }
@@ -128,10 +130,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     this(
         backoffFunction,
         scheduledExecutorService,
-        new Connector() {
-          @Override
-          public CompletionStage<RawMemcacheClient> connect() {
-            return DefaultRawMemcacheClient.connect(
+        () -> DefaultRawMemcacheClient.connect(
                 address,
                 outstandingRequestLimit,
                 eventLoopThreadFlushMaxBatchSize,
@@ -143,14 +142,8 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
                 maxSetLength,
                 eventLoopGroup,
                 channelClass,
-                sslEngineFactory);
-          }
-
-          @Override
-          public HostAndPort currentAddress() {
-            return address;
-          }
-        },
+                sslEngineFactory)
+            .thenApply(client -> Pair.of(client, address)),
         authenticator,
         new StandardReconnectionListener());
   }
@@ -164,17 +157,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     this(
         backoffFunction,
         scheduledExecutorService,
-        new Connector() {
-          @Override
-          public CompletionStage<RawMemcacheClient> connect() {
-            return AuthenticatingClient.authenticate(connector, authenticator);
-          }
-
-          @Override
-          public HostAndPort currentAddress() {
-            return connector.currentAddress();
-          }
-        },
+        () -> AuthenticatingClient.authenticate(connector, authenticator),
         reconnectionListener);
   }
 
@@ -194,19 +177,19 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
 
   @Override
   public <T> CompletionStage<T> send(final Request<T> request) {
-    return client.send(request);
+    return clientState.client.send(request);
   }
 
   @Override
   public void shutdown() {
     stayConnected = false;
-    client.shutdown();
+    clientState.client.shutdown();
     notifyConnectionChange();
   }
 
   @Override
   public boolean isConnected() {
-    return client.isConnected();
+    return clientState.client.isConnected();
   }
 
   @Override
@@ -216,29 +199,29 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
 
   @Override
   public int numTotalConnections() {
-    return client.numTotalConnections();
+    return clientState.client.numTotalConnections();
   }
 
   @Override
   public int numActiveConnections() {
-    return client.numActiveConnections();
+    return clientState.client.numActiveConnections();
   }
 
   @Override
   public int numPendingRequests() {
-    return this.client.numPendingRequests();
+    return clientState.client.numPendingRequests();
   }
 
   @Override
   public Stream<AddressAndClient> streamNodes() {
-    return client.streamNodes();
+    return clientState.client.streamNodes();
   }
 
   private void retry() {
     try {
-      final CompletionStage<RawMemcacheClient> future = connector.connect();
+      final CompletionStage<Pair<RawMemcacheClient, HostAndPort>> future = connector.connect();
       future.whenComplete(
-          (newClient, t) -> {
+          (clientData, t) -> {
             if (t != null) {
               this.reconnectionListener.connectionFailure(t);
 
@@ -250,10 +233,15 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
               }
               ReconnectingClient.this.onFailure(t);
             } else {
-              reconnectionListener.reconnectionSuccessful(connector.currentAddress(), reconnectCount, stayConnected);
+
+              RawMemcacheClient newClient = clientData.getLeft();
+              HostAndPort hostAndPort = clientData.getRight();
+
               reconnectCount = 0;
-              client.shutdown();
-              client = newClient;
+              clientState.client.shutdown();
+              clientState = new ClientState(newClient, hostAndPort);
+
+              reconnectionListener.reconnectionSuccessful(clientState.hostAndPort, reconnectCount, stayConnected);
 
               // Protection against races with shutdown()
               if (!stayConnected) {
@@ -268,7 +256,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
                   .disconnectFuture()
                   .whenComplete(
                       (unused, throwable) ->
-                          reconnectionListener.connectionLost(throwable, connector.currentAddress()))
+                          reconnectionListener.connectionLost(throwable, hostAndPort))
                   .thenRun(
                       () -> {
                         notifyConnectionChange();
@@ -292,7 +280,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
     final long backOff = backoffFunction.getBackoffTimeMillis(reconnectCount);
 
     reconnectCount++;
-    this.reconnectionListener.reconnectionQueuedFromError(cause, connector.currentAddress(), backOff, reconnectCount);
+    this.reconnectionListener.reconnectionQueuedFromError(cause, clientState.hostAndPort, backOff, reconnectCount);
 
     scheduledExecutorService.schedule(
         () -> {
@@ -310,7 +298,7 @@ public class ReconnectingClient extends AbstractRawMemcacheClient {
 
   @Override
   public String toString() {
-    return "Reconnecting(" + client + ")";
+    return "Reconnecting(" + clientState.client + ")";
   }
 
   /**

--- a/folsom/src/test/java/com/spotify/folsom/reconnect/ReconnectingClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/reconnect/ReconnectingClientTest.java
@@ -80,16 +80,31 @@ public class ReconnectingClientTest {
         .thenReturn(CompletableFutures.exceptionallyCompletedFuture(new RuntimeException()))
         .thenReturn(CompletableFutures.exceptionallyCompletedFuture(new RuntimeException()))
         .thenReturn(CompletableFuture.completedFuture(delegate));
+    when(connector.currentAddress())
+        .thenReturn(HostAndPort.fromString("localhost:123"));
+
+    ReconnectionListener listener = mock(ReconnectionListener.class);
 
     ReconnectingClient client =
         new ReconnectingClient(
             backoffFunction,
             scheduledExecutorService,
             connector,
-            HostAndPort.fromString("localhost:123"),
-            new ReconnectingClient.StandardReconnectionListener());
+            listener);
 
     verify(connector, times(3)).connect();
+    verify(listener, times(2))
+        .connectionFailure(Mockito.any());
+
+    HostAndPort expectedHostAndPort = connector.currentAddress();
+
+    verify(listener, times(1))
+        .reconnectionQueuedFromError(Mockito.any(Throwable.class), eq(expectedHostAndPort), anyLong(), eq(1));
+    verify(listener, times(1))
+        .reconnectionQueuedFromError(Mockito.any(Throwable.class), eq(expectedHostAndPort),
+            anyLong(), eq(2));
+    verify(listener, times(1))
+        .reconnectionSuccessful(eq(expectedHostAndPort), eq(2), eq(true));
     verify(scheduledExecutorService, times(1))
         .schedule(Mockito.<Runnable>any(), eq(0L), eq(TimeUnit.MILLISECONDS));
     verify(scheduledExecutorService, times(1))
@@ -97,7 +112,7 @@ public class ReconnectingClientTest {
     verify(backoffFunction, times(1)).getBackoffTimeMillis(0);
     verify(backoffFunction, times(1)).getBackoffTimeMillis(1);
 
-    verifyNoMoreInteractions(connector, scheduledExecutorService, backoffFunction);
+    verifyNoMoreInteractions(scheduledExecutorService, backoffFunction);
 
     assertTrue(client.isConnected());
   }
@@ -117,16 +132,22 @@ public class ReconnectingClientTest {
         .thenReturn(CompletableFutures.exceptionallyCompletedFuture(new RuntimeException()))
         .thenReturn(CompletableFutures.exceptionallyCompletedFuture(new RuntimeException()))
         .thenReturn(CompletableFuture.completedFuture(delegate2));
+    when(connector.currentAddress())
+        .thenReturn(HostAndPort.fromString("localhost:123"));
+    HostAndPort expectedHostAndPort = connector.currentAddress();
+
+    ReconnectionListener listener = mock(ReconnectionListener.class);
 
     ReconnectingClient client =
         new ReconnectingClient(
             backoffFunction,
             scheduledExecutorService,
             connector,
-            HostAndPort.fromString("localhost:123"),
-            new ReconnectingClient.StandardReconnectionListener());
+            listener);
 
     verify(connector, times(4)).connect();
+    verify(listener, times(1)).reconnectionSuccessful(eq(expectedHostAndPort), eq(0), eq(true));
+    verify(listener, times(1)).reconnectionSuccessful(eq(expectedHostAndPort), eq(2), eq(true));
     verify(scheduledExecutorService, times(1))
         .schedule(Mockito.<Runnable>any(), eq(0L), eq(TimeUnit.MILLISECONDS));
     verify(scheduledExecutorService, times(1))
@@ -134,7 +155,7 @@ public class ReconnectingClientTest {
     verify(backoffFunction, times(1)).getBackoffTimeMillis(0);
     verify(backoffFunction, times(1)).getBackoffTimeMillis(1);
 
-    verifyNoMoreInteractions(connector, scheduledExecutorService, backoffFunction);
+    verifyNoMoreInteractions(scheduledExecutorService, backoffFunction);
 
     assertTrue(client.isConnected());
   }
@@ -155,7 +176,6 @@ public class ReconnectingClientTest {
             backoffFunction,
             scheduledExecutorService,
             connector,
-            HostAndPort.fromString("localhost:123"),
             new ReconnectingClient.StandardReconnectionListener());
 
     assertTrue(client.isConnected());

--- a/folsom/src/test/java/com/spotify/folsom/reconnect/ReconnectingClientTest.java
+++ b/folsom/src/test/java/com/spotify/folsom/reconnect/ReconnectingClientTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
@@ -70,6 +71,7 @@ public class ReconnectingClientTest {
   @Test
   public void testInitialConnect() throws Exception {
     FakeClient delegate = new FakeClient(true, false);
+    HostAndPort hostAndPort = HostAndPort.fromString("localhost:123");
 
     BackoffFunction backoffFunction = mock(BackoffFunction.class);
     when(backoffFunction.getBackoffTimeMillis(0)).thenReturn(0L);
@@ -79,9 +81,7 @@ public class ReconnectingClientTest {
     when(connector.connect())
         .thenReturn(CompletableFutures.exceptionallyCompletedFuture(new RuntimeException()))
         .thenReturn(CompletableFutures.exceptionallyCompletedFuture(new RuntimeException()))
-        .thenReturn(CompletableFuture.completedFuture(delegate));
-    when(connector.currentAddress())
-        .thenReturn(HostAndPort.fromString("localhost:123"));
+        .thenReturn(CompletableFuture.completedFuture(Pair.of(delegate, hostAndPort)));
 
     ReconnectionListener listener = mock(ReconnectionListener.class);
 
@@ -96,15 +96,13 @@ public class ReconnectingClientTest {
     verify(listener, times(2))
         .connectionFailure(Mockito.any());
 
-    HostAndPort expectedHostAndPort = connector.currentAddress();
-
     verify(listener, times(1))
-        .reconnectionQueuedFromError(Mockito.any(Throwable.class), eq(expectedHostAndPort), anyLong(), eq(1));
+        .reconnectionQueuedFromError(Mockito.any(Throwable.class), eq(hostAndPort), anyLong(), eq(1));
     verify(listener, times(1))
-        .reconnectionQueuedFromError(Mockito.any(Throwable.class), eq(expectedHostAndPort),
+        .reconnectionQueuedFromError(Mockito.any(Throwable.class), eq(hostAndPort),
             anyLong(), eq(2));
     verify(listener, times(1))
-        .reconnectionSuccessful(eq(expectedHostAndPort), eq(2), eq(true));
+        .reconnectionSuccessful(eq(hostAndPort), eq(2), eq(true));
     verify(scheduledExecutorService, times(1))
         .schedule(Mockito.<Runnable>any(), eq(0L), eq(TimeUnit.MILLISECONDS));
     verify(scheduledExecutorService, times(1))
@@ -121,6 +119,7 @@ public class ReconnectingClientTest {
   public void testLostConnectionRetry() throws Exception {
     FakeClient delegate1 = new FakeClient(true, true);
     FakeClient delegate2 = new FakeClient(true, false);
+    HostAndPort hostAndPort = HostAndPort.fromString("localhost:123");
 
     BackoffFunction backoffFunction = mock(BackoffFunction.class);
     when(backoffFunction.getBackoffTimeMillis(0)).thenReturn(0L);
@@ -128,13 +127,10 @@ public class ReconnectingClientTest {
 
     Connector connector = mock(Connector.class);
     when(connector.connect())
-        .thenReturn(CompletableFuture.completedFuture(delegate1))
+        .thenReturn(CompletableFuture.completedFuture(Pair.of(delegate1, hostAndPort)))
         .thenReturn(CompletableFutures.exceptionallyCompletedFuture(new RuntimeException()))
         .thenReturn(CompletableFutures.exceptionallyCompletedFuture(new RuntimeException()))
-        .thenReturn(CompletableFuture.completedFuture(delegate2));
-    when(connector.currentAddress())
-        .thenReturn(HostAndPort.fromString("localhost:123"));
-    HostAndPort expectedHostAndPort = connector.currentAddress();
+        .thenReturn(CompletableFuture.completedFuture(Pair.of(delegate2, hostAndPort)));
 
     ReconnectionListener listener = mock(ReconnectionListener.class);
 
@@ -146,8 +142,8 @@ public class ReconnectingClientTest {
             listener);
 
     verify(connector, times(4)).connect();
-    verify(listener, times(1)).reconnectionSuccessful(eq(expectedHostAndPort), eq(0), eq(true));
-    verify(listener, times(1)).reconnectionSuccessful(eq(expectedHostAndPort), eq(2), eq(true));
+    verify(listener, times(1)).reconnectionSuccessful(eq(hostAndPort), eq(0), eq(true));
+    verify(listener, times(1)).reconnectionSuccessful(eq(hostAndPort), eq(2), eq(true));
     verify(scheduledExecutorService, times(1))
         .schedule(Mockito.<Runnable>any(), eq(0L), eq(TimeUnit.MILLISECONDS));
     verify(scheduledExecutorService, times(1))
@@ -163,13 +159,14 @@ public class ReconnectingClientTest {
   @Test
   public void testShutdown() throws Exception {
     FakeClient delegate = new FakeClient(true, false);
+    HostAndPort hostAndPort = HostAndPort.fromString("localhost:123");
 
     BackoffFunction backoffFunction = mock(BackoffFunction.class);
     when(backoffFunction.getBackoffTimeMillis(0)).thenReturn(0L);
     when(backoffFunction.getBackoffTimeMillis(1)).thenReturn(123L);
 
     Connector connector = mock(Connector.class);
-    when(connector.connect()).thenReturn(CompletableFuture.completedFuture(delegate));
+    when(connector.connect()).thenReturn(CompletableFuture.completedFuture(Pair.of(delegate, hostAndPort)));
 
     ReconnectingClient client =
         new ReconnectingClient(


### PR DESCRIPTION
This is useful for two reasons:
1. The address passed into ReconnectingClient is hardcoded and ought to be derived from where the connection is created
2. Allows us to utilize more robust client logic within Connectors we pass to ReconnectingClient. For example, a client that switches between IP addresses when connections fail.